### PR TITLE
Jetpack 6.1 (R36.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 jetson_linux_r35.3.1_aarch64.tbz2
 tegra_linux_sample-root-filesystem_r35.3.1_aarch64.tbz2
-Linux_for_Tegra/
 ark_jetson_compiled_device_tree_files/
-ark_jetson_orin_nano_nx_device_tree/
-public_sources.tbz2
 prebuilt/
+source_build/
+output.txt

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ make dtbs
 
 Copy the overlay DTB to the Jetson via Micro-USB
 ```
-DTB_PATH="$ARK_JETSON_KERNEL_DIR/source_build/Linux_for_Tegra/source/kernel_out/nvidia-oot/device-tree/platform/generic-dts/dtbs/"
+DTB_PATH="$ARK_JETSON_KERNEL_DIR/source_build/Linux_for_Tegra/source/kernel-devicetree/generic-dts/dtbs/"
 OVERLAY_DTB=<your_overlay>
 scp $DTB_PATH/$OVERLAY_DTB jetson@192.168.55.1:~
 ```
@@ -125,6 +125,10 @@ sudo /opt/nvidia/jetson-io/config-by-hardware.py -n 2="Camera ARK IMX477 Single"
 Reboot and your new device tree will be active.
 ```
 sudo reboot
+```
+You can check that LibArgus can find your camera sensor
+```
+nvargus_nvraw --lps
 ```
 
 ---

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -4,8 +4,17 @@ sudo -v
 export CROSS_COMPILE=$HOME/l4t-gcc/aarch64--glibc--stable-2022.08-1/bin/aarch64-buildroot-linux-gnu-
 export KERNEL_HEADERS=$ARK_JETSON_KERNEL_DIR/source_build/Linux_for_Tegra/source/kernel/kernel-jammy-src
 export INSTALL_MOD_PATH=$ARK_JETSON_KERNEL_DIR/prebuilt/Linux_for_Tegra/rootfs/
-cd $ARK_JETSON_KERNEL_DIR/source_build/Linux_for_Tegra/source
+
+pushd .
+
+cd $ARK_JETSON_KERNEL_DIR/source_build/
+echo "Copying ARK device tree files"
+cp -r ark_jetson_orin_nano_nx_device_tree/* Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/
+
+cd Linux_for_Tegra/source
 make -C kernel && make modules && make dtbs
 sudo -E make install -C kernel
 cp kernel/kernel-jammy-src/arch/arm64/boot/Image ../../../prebuilt/Linux_for_Tegra/kernel/
 $ARK_JETSON_KERNEL_DIR/copy_dtbs_to_prebuilt.sh
+
+popd

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+START_TIME=$(date +%s)
+
 sudo -v
 export CROSS_COMPILE=$HOME/l4t-gcc/aarch64--glibc--stable-2022.08-1/bin/aarch64-buildroot-linux-gnu-
 export KERNEL_HEADERS=$ARK_JETSON_KERNEL_DIR/source_build/Linux_for_Tegra/source/kernel/kernel-jammy-src
@@ -9,12 +11,17 @@ pushd .
 
 cd $ARK_JETSON_KERNEL_DIR/source_build/
 echo "Copying ARK device tree files"
-cp -r ark_jetson_orin_nano_nx_device_tree/* Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/
+cp -r ark_jetson_orin_nano_nx_device_tree/Linux_for_Tegra/* Linux_for_Tegra/
 
 cd Linux_for_Tegra/source
 make -C kernel && make modules && make dtbs
 sudo -E make install -C kernel
 cp kernel/kernel-jammy-src/arch/arm64/boot/Image ../../../prebuilt/Linux_for_Tegra/kernel/
 $ARK_JETSON_KERNEL_DIR/copy_dtbs_to_prebuilt.sh
+
+END_TIME=$(date +%s)
+TOTAL_TIME=$((${END_TIME}-${START_TIME}))
+echo "Build complete in $(date -d@${TOTAL_TIME} -u +%H:%M:%S)"
+echo "You can now flash the device with ./flash.sh"
 
 popd

--- a/copy_dtbs_to_prebuilt.sh
+++ b/copy_dtbs_to_prebuilt.sh
@@ -26,6 +26,9 @@ sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx477-single.dtbo $PR
 # IMX219 Quad
 sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-quad.dtbo $PREBUILT_PATH/rootfs/boot/
 sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-quad.dtbo $PREBUILT_PATH/kernel/dtb/
+# IMX219 Single
+sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-single.dtbo $PREBUILT_PATH/rootfs/boot/
+sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-single.dtbo $PREBUILT_PATH/kernel/dtb/
 
 echo "Removing non-supported overlays from prebuilt directory"
 # Remove the overlays that don't work with ARK Carrier
@@ -70,3 +73,6 @@ sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx477-single.dtbo $AR
 # IMX219 Quad
 sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-quad.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/rootfs/boot/
 sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-quad.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/kernel/dtb/
+# IMX219 Single
+sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-single.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/rootfs/boot/
+sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-single.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/kernel/dtb/

--- a/copy_dtbs_to_prebuilt.sh
+++ b/copy_dtbs_to_prebuilt.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
-DTBS_SOURCE_PATH="$ARK_JETSON_KERNEL_DIR/source_build/Linux_for_Tegra/source/kernel-devicetree/generic-dts/dtbs/"
-
+SOURCE_BUILD_PATH="$ARK_JETSON_KERNEL_DIR/source_build/Linux_for_Tegra/"
+DTBS_SOURCE_PATH="$SOURCE_BUILD_PATH/source/kernel-devicetree/generic-dts/dtbs/"
 PREBUILT_PATH="$ARK_JETSON_KERNEL_DIR/prebuilt/Linux_for_Tegra"
-ARK_COMPILED_DEVICE_TREE_PATH="$ARK_JETSON_KERNEL_DIR/prebuilt/ark_jetson_compiled_device_tree_files/Linux_for_Tegra"
+
+echo "Installing bootloader DTSI files into prebuilt directory"
+echo "(previously from ark_jetson_compiled_device_tree_files)"
+sudo cp $SOURCE_BUILD_PATH/bootloader/tegra234-mb1-bct-gpio-p3767-dp-a03.dtsi $PREBUILT_PATH/bootloader/
+sudo cp $SOURCE_BUILD_PATH/bootloader/generic/BCT/tegra234-mb1-bct-padvoltage-p3767-dp-a03.dtsi $PREBUILT_PATH/bootloader/generic/BCT/
+sudo cp $SOURCE_BUILD_PATH/bootloader/generic/BCT/tegra234-mb1-bct-pinmux-p3767-dp-a03.dtsi $PREBUILT_PATH/bootloader/generic/BCT/
+sudo cp $SOURCE_BUILD_PATH/bootloader/generic/BCT/tegra234-mb2-bct-misc-p3767-0000.dts $PREBUILT_PATH/bootloader/generic/BCT/
 
 echo "Installing DTBs into prebuilt directory"
 # Copy kernel device tree to bootloader path
@@ -33,7 +39,17 @@ sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-single.dtbo $PR
 echo "Removing non-supported overlays from prebuilt directory"
 # Remove the overlays that don't work with ARK Carrier
 file_names=(
-	# TODO: remove overlays
+    "tegra234-p3767-camera-p3768-imx219-A.dtbo"
+    "tegra234-p3767-camera-p3768-imx219-ark-quad.dtbo"
+    "tegra234-p3767-camera-p3768-imx219-C.dtbo"
+    "tegra234-p3767-camera-p3768-imx219-dual.dtbo"
+    "tegra234-p3767-camera-p3768-imx219-imx477.dtbo"
+    "tegra234-p3767-camera-p3768-imx477-A.dtbo"
+    "tegra234-p3767-camera-p3768-imx477-C.dtbo"
+    "tegra234-p3767-camera-p3768-imx477-dual-4lane.dtbo"
+    "tegra234-p3767-camera-p3768-imx477-dual.dtbo"
+    "tegra234-p3767-camera-p3768-imx477-imx219.dtbo"
+    "tegra234-p3767-camera-p3768-ov5647-single.dtbo"
 )
 
 for file in "${file_names[@]}"
@@ -50,29 +66,3 @@ do
         sudo rm $filepath
     fi
 done
-
-echo "Installing DTBs into ark_jetson_compiled_device_tree_files directory"
-# Copy kernel device tree to bootloader path
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3768-0000+p3767-0000-nv.dtb $ARK_COMPILED_DEVICE_TREE_PATH/rootfs/boot/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3768-0000+p3767-0001-nv.dtb $ARK_COMPILED_DEVICE_TREE_PATH/rootfs/boot/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3768-0000+p3767-0003-nv.dtb $ARK_COMPILED_DEVICE_TREE_PATH/rootfs/boot/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3768-0000+p3767-0004-nv.dtb $ARK_COMPILED_DEVICE_TREE_PATH/rootfs/boot/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3768-0000+p3767-0000-dynamic.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/rootfs/boot/
-
-# Copy kernel device tree to kernel path
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3768-0000+p3767-0000-nv.dtb $ARK_COMPILED_DEVICE_TREE_PATH/kernel/dtb/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3768-0000+p3767-0001-nv.dtb $ARK_COMPILED_DEVICE_TREE_PATH/kernel/dtb/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3768-0000+p3767-0003-nv.dtb $ARK_COMPILED_DEVICE_TREE_PATH/kernel/dtb/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3768-0000+p3767-0004-nv.dtb $ARK_COMPILED_DEVICE_TREE_PATH/kernel/dtb/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3768-0000+p3767-0000-dynamic.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/kernel/dtb/
-
-# Copy camera overlays to kernel and bootloader paths
-# IMX477 Single
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx477-single.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/rootfs/boot/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx477-single.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/kernel/dtb/
-# IMX219 Quad
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-quad.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/rootfs/boot/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-quad.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/kernel/dtb/
-# IMX219 Single
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-single.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/rootfs/boot/
-sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-single.dtbo $ARK_COMPILED_DEVICE_TREE_PATH/kernel/dtb/

--- a/copy_dtbs_to_prebuilt.sh
+++ b/copy_dtbs_to_prebuilt.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-DTBS_SOURCE_PATH="$ARK_JETSON_KERNEL_DIR/source_build/Linux_for_Tegra/source/nvidia-oot/device-tree/platform/generic-dts/dtbs"
+DTBS_SOURCE_PATH="$ARK_JETSON_KERNEL_DIR/source_build/Linux_for_Tegra/source/kernel-devicetree/generic-dts/dtbs/"
+
 PREBUILT_PATH="$ARK_JETSON_KERNEL_DIR/prebuilt/Linux_for_Tegra"
 ARK_COMPILED_DEVICE_TREE_PATH="$ARK_JETSON_KERNEL_DIR/prebuilt/ark_jetson_compiled_device_tree_files/Linux_for_Tegra"
 
@@ -29,17 +30,7 @@ sudo cp $DTBS_SOURCE_PATH/tegra234-p3767-camera-p3768-ark-imx219-quad.dtbo $PREB
 echo "Removing non-supported overlays from prebuilt directory"
 # Remove the overlays that don't work with ARK Carrier
 file_names=(
-	"tegra234-p3767-camera-p3768-imx219-A.dtbo"
-	"tegra234-p3767-camera-p3768-imx219-ark-quad.dtbo"
-	"tegra234-p3767-camera-p3768-imx219-C.dtbo"
-	"tegra234-p3767-camera-p3768-imx219-dual.dtbo"
-	"tegra234-p3767-camera-p3768-imx219-imx477.dtbo"
-	"tegra234-p3767-camera-p3768-imx477-A.dtbo"
-	"tegra234-p3767-camera-p3768-imx477-C.dtbo"
-	"tegra234-p3767-camera-p3768-imx477-dual-4lane.dtbo"
-	"tegra234-p3767-camera-p3768-imx477-dual.dtbo"
-	"tegra234-p3767-camera-p3768-imx477-imx219.dtbo"
-	"tegra234-p3767-camera-p3768-ov5647-single.dtbo"
+	# TODO: remove overlays
 )
 
 for file in "${file_names[@]}"

--- a/setup.sh
+++ b/setup.sh
@@ -166,8 +166,6 @@ rm -rf ark_jetson_orin_nano_nx_device_tree
 # git clone -b ark_36.3.0.1 https://github.com/ARK-Electronics/ark_jetson_orin_nano_nx_device_tree.git
 git clone -b pr-36.4 https://github.com/ARK-Electronics/ark_jetson_orin_nano_nx_device_tree.git
 
-echo "Copying ARK device tree files"
-cp -r ark_jetson_orin_nano_nx_device_tree/* Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/
 popd
 
 END_TIME=$(date +%s)

--- a/setup.sh
+++ b/setup.sh
@@ -84,12 +84,6 @@ sudo Linux_for_Tegra/tools/l4t_flash_prerequisites.sh
 echo "Applying binaries"
 sudo Linux_for_Tegra/apply_binaries.sh --debug
 
-# Apply ARK compile device tree
-rm -rf ark_jetson_compiled_device_tree_files
-git clone -b ark_36.3.0.2 https://github.com/ARK-Electronics/ark_jetson_compiled_device_tree_files.git
-echo "Copying device tree files"
-sudo cp -r ark_jetson_compiled_device_tree_files/Linux_for_Tegra/* Linux_for_Tegra/
-
 echo "Setting up login credentials for the Jetson"
 sudo -E $ARK_JETSON_KERNEL_DIR/configure_user.sh
 
@@ -163,14 +157,13 @@ popd
 # Clone ARK device tree
 echo "Downloading ARK device tree"
 rm -rf ark_jetson_orin_nano_nx_device_tree
-# git clone -b ark_36.3.0.1 https://github.com/ARK-Electronics/ark_jetson_orin_nano_nx_device_tree.git
-git clone -b pr-36.4 https://github.com/ARK-Electronics/ark_jetson_orin_nano_nx_device_tree.git
+git clone -b ark_36.4.0 https://github.com/ARK-Electronics/ark_jetson_orin_nano_nx_device_tree.git
 
 popd
 
 END_TIME=$(date +%s)
 TOTAL_TIME=$((${END_TIME}-${START_TIME}))
-echo "Finished -- $(date -d@${TOTAL_TIME} -u +%H:%M:%S)"
-echo "You can now flash the device"
+echo "Setup complete in $(date -d@${TOTAL_TIME} -u +%H:%M:%S)"
+echo "You can now build the kernel with ./build_kernel.sh"
 
 cleanup


### PR DESCRIPTION
- Jetpack 6.1 https://docs.nvidia.com/jetson/jetpack/release-notes/index.html
- Fix IMX477 Single overlay (fixes #14)
- Added IMX219 Single overlay as another example
- Restructured https://github.com/ARK-Electronics/ark_jetson_orin_nano_nx_device_tree and unified with https://github.com/ARK-Electronics/ark_jetson_compiled_device_tree_files