### PR TITLE
Add imx219 tuning params to filesystem

### DIFF
--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -21,8 +21,6 @@ cp kernel/kernel-jammy-src/arch/arm64/boot/Image ../../../prebuilt/Linux_for_Teg
 $ARK_JETSON_KERNEL_DIR/copy_dtbs_to_prebuilt.sh
 $ARK_JETSON_KERNEL_DIR/copy_camera_params_to_prebuilt.sh
 
-
-
 END_TIME=$(date +%s)
 TOTAL_TIME=$((${END_TIME}-${START_TIME}))
 echo "Build complete in $(date -d@${TOTAL_TIME} -u +%H:%M:%S)"

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -19,6 +19,9 @@ make -C kernel && make modules && make dtbs
 sudo -E make install -C kernel
 cp kernel/kernel-jammy-src/arch/arm64/boot/Image ../../../prebuilt/Linux_for_Tegra/kernel/
 $ARK_JETSON_KERNEL_DIR/copy_dtbs_to_prebuilt.sh
+$ARK_JETSON_KERNEL_DIR/copy_camera_params_to_prebuilt.sh
+
+
 
 END_TIME=$(date +%s)
 TOTAL_TIME=$((${END_TIME}-${START_TIME}))

--- a/copy_camera_params_to_prebuilt.sh
+++ b/copy_camera_params_to_prebuilt.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+DOWNLOAD_URL="https://files.waveshare.com/upload/e/eb/Camera_overrides.tar.gz"
+TAR_FILE="Camera_overrides.tar.gz"
+ISP_FILE="camera_overrides.isp"
+DEST_DIR="$ARK_JETSON_KERNEL_DIR/prebuilt/Linux_for_Tegra/rootfs/var/nvidia/nvcam/settings"
+
+if [ -f "$DEST_DIR/$ISP_FILE" ]; then
+    echo "Camera overrides file already exists at $DEST_DIR/$ISP_FILE"
+    echo "Nothing to do. Exiting."
+    exit 0
+fi
+
+echo "Camera overrides file not found in $DEST_DIR. Downloading and installing..."
+
+echo "Downloading $TAR_FILE..."
+wget "$DOWNLOAD_URL"
+
+echo "Extracting $TAR_FILE..."
+tar zxvf "$TAR_FILE"
+
+echo "Copying $ISP_FILE to $DEST_DIR..."
+sudo cp "$ISP_FILE" "$DEST_DIR/"
+
+echo "Installation completed successfully!"

--- a/copy_camera_params_to_prebuilt.sh
+++ b/copy_camera_params_to_prebuilt.sh
@@ -7,7 +7,6 @@ DEST_DIR="$ARK_JETSON_KERNEL_DIR/prebuilt/Linux_for_Tegra/rootfs/var/nvidia/nvca
 
 if [ -f "$DEST_DIR/$ISP_FILE" ]; then
     echo "Camera overrides file already exists at $DEST_DIR/$ISP_FILE"
-    echo "Nothing to do. Exiting."
     exit 0
 fi
 
@@ -20,6 +19,8 @@ echo "Extracting $TAR_FILE..."
 tar zxvf "$TAR_FILE"
 
 echo "Copying $ISP_FILE to $DEST_DIR..."
-sudo cp "$ISP_FILE" "$DEST_DIR/"
+sudo mv "$ISP_FILE" "$DEST_DIR/"
 
 echo "Installation completed successfully!"
+
+rm $TAR_FILE


### PR DESCRIPTION
Fixes issue with CSI0 and CSI2 quality. For some reason the IMX219 tuning parameters are not applied to these ports, probably because the nvidia jetson orin dev kit only has 2 CSI ports, whereas we have 4x 2-lane ports. 

Solved from here
https://www.waveshare.com/wiki/IMX219-77_Camera