### PR TITLE
Build target safety: auto-clean on switch, fix DTS model strings, flash confirmation

### DIFF
--- a/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0001.dts
+++ b/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0001.dts
@@ -9,5 +9,5 @@
 
 / {
 	compatible = "nvidia,p3768-0000+p3767-0001", "nvidia,p3767-0001", "nvidia,tegra234";
-	model = "NVIDIA Jetson Orin NX 8GB ARK PAB Jetson Carrier";
+	model = "NVIDIA Jetson Orin NX 8GB ARK JAJ Jetson Carrier";
 };

--- a/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0003.dts
+++ b/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0003.dts
@@ -9,5 +9,5 @@
 
 / {
 	compatible = "nvidia,p3768-0000+p3767-0003", "nvidia,p3767-0003", "nvidia,tegra234";
-	model = "NVIDIA Jetson Orin Nano 8GB ARK PAB Jetson Carrier";
+	model = "NVIDIA Jetson Orin Nano 8GB ARK JAJ Jetson Carrier";
 };

--- a/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0004.dts
+++ b/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0004.dts
@@ -9,5 +9,5 @@
 
 / {
 	compatible = "nvidia,p3768-0000+p3767-0004", "nvidia,p3767-0004", "nvidia,tegra234";
-	model = "NVIDIA Jetson Orin Nano 4GB ARK PAB Jetson Carrier";
+	model = "NVIDIA Jetson Orin Nano 4GB ARK JAJ Jetson Carrier";
 };

--- a/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/tegra234-p3768-0000+p3767-0000.dts
+++ b/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/tegra234-p3768-0000+p3767-0000.dts
@@ -9,7 +9,7 @@
 
 / {
 	compatible = "nvidia,p3768-0000+p3767-0000", "nvidia,p3767-0000", "nvidia,tegra234";
-	model = "NVIDIA Jetson Orin NX 16GB ARK PAB Jetson Carrier";
+	model = "NVIDIA Jetson Orin NX 16GB ARK JAJ Jetson Carrier";
 
 	aliases {
 		serial1 = &uarta;

--- a/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0001.dts
+++ b/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0001.dts
@@ -9,5 +9,5 @@
 
 / {
 	compatible = "nvidia,p3768-0000+p3767-0001", "nvidia,p3767-0001", "nvidia,tegra234";
-	model = "NVIDIA Jetson Orin NX 8GB ARK PAB Jetson Carrier";
+	model = "NVIDIA Jetson Orin NX 8GB ARK PAB_V3 Jetson Carrier";
 };

--- a/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0003.dts
+++ b/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0003.dts
@@ -9,5 +9,5 @@
 
 / {
 	compatible = "nvidia,p3768-0000+p3767-0003", "nvidia,p3767-0003", "nvidia,tegra234";
-	model = "NVIDIA Jetson Orin Nano 8GB ARK PAB Jetson Carrier";
+	model = "NVIDIA Jetson Orin Nano 8GB ARK PAB_V3 Jetson Carrier";
 };

--- a/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0004.dts
+++ b/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/staging/tegra234-p3768-0000+p3767-0004.dts
@@ -9,5 +9,5 @@
 
 / {
 	compatible = "nvidia,p3768-0000+p3767-0004", "nvidia,p3767-0004", "nvidia,tegra234";
-	model = "NVIDIA Jetson Orin Nano 4GB ARK PAB Jetson Carrier";
+	model = "NVIDIA Jetson Orin Nano 4GB ARK PAB_V3 Jetson Carrier";
 };

--- a/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/tegra234-p3768-0000+p3767-0000.dts
+++ b/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/tegra234-p3768-0000+p3767-0000.dts
@@ -9,7 +9,7 @@
 
 / {
 	compatible = "nvidia,p3768-0000+p3767-0000", "nvidia,p3767-0000", "nvidia,tegra234";
-	model = "NVIDIA Jetson Orin NX 16GB ARK PAB Jetson Carrier";
+	model = "NVIDIA Jetson Orin NX 16GB ARK PAB_V3 Jetson Carrier";
 
 	aliases {
 		serial1 = &uarta;

--- a/flash.sh
+++ b/flash.sh
@@ -4,6 +4,27 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec > >(tee "$SCRIPT_DIR/flash.log.txt") 2>&1
 
+# Pre-flash target confirmation
+LAST_TARGET_FILE="$SCRIPT_DIR/source_build/LAST_BUILT_TARGET"
+if [ -f "$LAST_TARGET_FILE" ]; then
+    LAST_TARGET=$(cat "$LAST_TARGET_FILE")
+    echo "========================================="
+    echo "  Built target: $LAST_TARGET"
+    echo "========================================="
+    read -p "Flash this target? (y/N): " confirm
+    if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+        echo "Flash aborted."
+        exit 0
+    fi
+else
+    echo "WARNING: No LAST_BUILT_TARGET file found — cannot confirm which target was built."
+    read -p "Continue anyway? (y/N): " confirm
+    if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+        echo "Flash aborted."
+        exit 0
+    fi
+fi
+
 sudo -v
 
 echo "Waiting for device..."


### PR DESCRIPTION
  Summary

  - Auto-clean kernel and OOT build artifacts when build_kernel.sh detects a target switch (e.g. JAJ → PAB), preventing stale DTBs and object files from contaminating the output
  - Inject ARK target name into nv-super.dts model strings at build time so flashed devices are identifiable via cat /sys/firmware/devicetree/base/model
  - Fix copy-paste bug where all JAJ and PAB_V3 DTS files incorrectly said "ARK PAB" — now correctly say "ARK JAJ" and "ARK PAB_V3" respectively
  - Add pre-flash target confirmation prompt in flash.sh with safe default (abort) to prevent accidental flashes of the wrong target

  Test plan

  - Set LAST_BUILT_TARGET to a different target, run build_kernel.sh, confirm clean triggers before build
  - Run build_kernel.sh with same target — confirm no clean happens
  - Run flash.sh — confirm target prompt appears before device wait
  - grep -r "ARK PAB" device_tree/ark_jaj/ device_tree/ark_pab_v3/ returns only ARK PAB_V3 matches
  - After flashing, cat /sys/firmware/devicetree/base/model shows correct ARK target identifier
