### PR TITLE
added SD card flashing option and non-super target

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,20 @@ Flash the image:
 ./flash.sh
 ```
 
-> **NVIDIA Dev Kit Modules:** The `flash.sh` script flashes to NVMe (`nvme0n1p1`), which is correct for production Jetson modules on the ARK PAB carrier. If you are using a **Jetson module from an NVIDIA Developer Kit**, these modules have an SD card instead of NVMe and boot from the SD card. You will need to flash using the SD card command instead:
-> ```
-> cd prebuilt/Linux_for_Tegra/
-> sudo ./tools/kernel_flash/l4t_initrd_flash.sh --external-device mmcblk0p1 \
->     -c tools/kernel_flash/flash_l4t_t234_nvme.xml \
->     -p "-c bootloader/generic/cfg/flash_t234_qspi.xml" \
->     --showlogs --network usb0 \
->     jetson-orin-nano-devkit-super internal
-> ```
+#### Flash options
+
+By default, `flash.sh` targets NVMe + Orin Super. For other configurations:
+
+```
+# Flash to SD card (NVIDIA dev kit modules)
+./flash.sh --sdcard
+
+# Flash non-super module variant
+./flash.sh --no-super
+
+# Both
+./flash.sh --sdcard --no-super
+```
 
 Once complete, SSH in via Micro USB or WiFi.
 ```

--- a/flash.sh
+++ b/flash.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+# Defaults: NVMe + super (ARK PAB carrier)
+STORAGE_DEV="nvme0n1p1"
+USE_INITRD=true
+FLASH_TARGET="jetson-orin-nano-devkit-super"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --sdcard)
+            STORAGE_DEV="mmcblk0p1"
+            USE_INITRD=false
+            shift ;;
+        --no-super)
+            FLASH_TARGET="jetson-orin-nano-devkit"
+            shift ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: ./flash.sh [--sdcard] [--no-super]"
+            exit 1 ;;
+    esac
+done
+
 # Log output to file while keeping terminal output
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec > >(tee "$SCRIPT_DIR/flash.log.txt") 2>&1
@@ -35,7 +56,15 @@ done
 
 pushd .
 cd prebuilt/Linux_for_Tegra/
-sudo ./tools/kernel_flash/l4t_initrd_flash.sh --external-device nvme0n1p1 \
-	-p "-c ./bootloader/generic/cfg/flash_t234_qspi.xml" -c ./tools/kernel_flash/flash_l4t_t234_nvme.xml \
-	--erase-all --showlogs --network usb0 jetson-orin-nano-devkit-super nvme0n1p1
+if [ "$USE_INITRD" = true ]; then
+    # NVMe flash
+    sudo ./tools/kernel_flash/l4t_initrd_flash.sh --external-device "$STORAGE_DEV" \
+        -p "-c ./bootloader/generic/cfg/flash_t234_qspi.xml" \
+        -c ./tools/kernel_flash/flash_l4t_t234_nvme.xml \
+        --erase-all --showlogs --network usb0 \
+        "$FLASH_TARGET" "$STORAGE_DEV"
+else
+    # SD card flash
+    sudo ./flash.sh "$FLASH_TARGET" "$STORAGE_DEV"
+fi
 popd


### PR DESCRIPTION
  ## Summary

  - Add `--sdcard` flag to flash to SD card (`mmcblk0p1`) using NVIDIA's `flash.sh` instead of `l4t_initrd_flash.sh`
  - Add `--no-super` flag to target `jetson-orin-nano-devkit` instead of `jetson-orin-nano-devkit-super`
  - Default behavior (NVMe + super) is unchanged when no flags are passed
  - Update README with new flash options, replacing the old manual SD card instructions

  ## Test plan

  - [ ] Run `./flash.sh --badflag` — confirms usage message and exits
  - [ ] Read through script to verify no-flag path is identical to previous behavior
  - [ ] Flash with `--sdcard` on an NVIDIA dev kit module
  - [ ] Flash with `--no-super` on a non-super module