### PR TITLE
flash: add --usb flag for USB thumb drive flashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ By default, `flash.sh` targets NVMe + Orin Super. For other configurations:
 # Flash to SD card (NVIDIA dev kit modules)
 ./flash.sh --sdcard
 
+# Flash to USB thumb drive
+./flash.sh --usb
+
 # Flash non-super module variant
 ./flash.sh --no-super
 

--- a/flash.sh
+++ b/flash.sh
@@ -12,7 +12,7 @@ while [[ $# -gt 0 ]]; do
             USE_INITRD=false
             shift ;;
         --usb)
-            STORAGE_DEV="sda1"
+            STORAGE_DEV="sda"
             shift ;;
         --no-super)
             FLASH_TARGET="jetson-orin-nano-devkit"

--- a/flash.sh
+++ b/flash.sh
@@ -11,12 +11,15 @@ while [[ $# -gt 0 ]]; do
             STORAGE_DEV="mmcblk0p1"
             USE_INITRD=false
             shift ;;
+        --usb)
+            STORAGE_DEV="sda1"
+            shift ;;
         --no-super)
             FLASH_TARGET="jetson-orin-nano-devkit"
             shift ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: ./flash.sh [--sdcard] [--no-super]"
+            echo "Usage: ./flash.sh [--sdcard] [--usb] [--no-super]"
             exit 1 ;;
     esac
 done


### PR DESCRIPTION
## Summary
- Add `--usb` flag to `flash.sh` that sets `STORAGE_DEV="sda"` for USB thumb drive flashing
- Update usage string and README

Replaces #48 with a minimal change (no drive-by modifications).

## Test plan
- [ ] Flash to USB thumb drive with `./flash.sh --usb`
- [ ] Verify NVMe flash still works with `./flash.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)