### PR TITLE
feat(dt): add AR0234 dual camera overlay for p3768

### DIFF
--- a/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/Makefile
+++ b/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/Makefile
@@ -60,6 +60,7 @@ dtbo-y += tegra234-p3737-camera-p3762-a00-overlay.dtbo
 dtbo-y += tegra234-p3740-camera-p3783-a00-overlay.dtbo
 dtbo-y += tegra234-p3767-camera-p3768-imx219-C.dtbo
 dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
+dtbo-y += tegra234-p3767-camera-p3768-ar0234-dual.dtbo
 dtbo-y += ark_i2s_gpio.dtbo
 
 ifneq ($(dtb-y),)

--- a/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ar0234-dual.dts
+++ b/device_tree/ark_jaj/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ar0234-dual.dts
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+/dts-v1/;
+/plugin/;
+
+#define CAM0_PWDN	TEGRA234_MAIN_GPIO(H, 6)
+#define CAM1_PWDN	TEGRA234_MAIN_GPIO(AC, 0)
+#define CAM_I2C_MUX 	TEGRA234_AON_GPIO(CC, 3)
+
+#include <dt-bindings/tegra234-p3767-0000-common.h>
+
+/ {
+	overlay-name = "Camera AR0234 Dual";
+	jetson-header-name = "Jetson 24pin CSI Connector";
+	compatible = JETSON_COMPATIBLE_P3768;
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <2>;
+				ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+					port@0 {
+						reg = <0>;
+						ar0234_vi_in0: endpoint {
+							port-index = <1>;
+							bus-width = <2>;
+							remote-endpoint = <&ar0234_csi_out0>;
+						};
+					};
+					port@1 {
+						reg = <1>;
+						ar0234_vi_in1: endpoint {
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&ar0234_csi_out1>;
+						};
+					};
+				};
+			};
+			tegra-camera-platform {
+				compatible = "nvidia, tegra-camera-platform";
+				num_csi_lanes = <4>;
+				max_lane_speed = <1500000>;
+				min_bits_per_pixel = <10>;
+				vi_peak_byte_per_pixel = <2>;
+				vi_bw_margin_pct = <25>;
+				max_pixel_rate = <7500000>;
+				isp_peak_byte_per_pixel = <5>;
+				isp_bw_margin_pct = <25>;
+				modules {
+					module0 {
+						badge = "jakku_front_ar0234";
+						position = "front";
+						orientation = "1";
+						drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@0/ar0234_a@10";
+						};
+					};
+					module1 {
+						badge = "jakku_rear_ar0234";
+						position = "rear";
+						orientation = "1";
+						drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ar0234_c@10";
+						};
+					};
+				};
+			};
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <2>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+						channel@0 {
+							reg = <0>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									reg = <0>;
+									ar0234_csi_in0: endpoint@0 {
+										port-index = <1>;
+										bus-width = <2>;
+										remote-endpoint = <&ar0234_out0>;
+									};
+								};
+								port@1 {
+									reg = <1>;
+									ar0234_csi_out0: endpoint@1 {
+										remote-endpoint = <&ar0234_vi_in0>;
+									};
+								};
+							};
+						};
+						channel@1 {
+							reg = <1>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									reg = <0>;
+									ar0234_csi_in1: endpoint@2 {
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ar0234_out1>;
+									};
+								};
+								port@1 {
+									reg = <1>;
+									ar0234_csi_out1: endpoint@3 {
+										remote-endpoint = <&ar0234_vi_in1>;
+									};
+								};
+							};
+						};
+					};
+				};
+				cam_i2cmux {
+					status = "okay";
+					compatible = "i2c-mux-gpio";
+					#address-cells = <1>;
+					#size-cells = <0>;
+					mux-gpios = <&gpio_aon CAM_I2C_MUX GPIO_ACTIVE_HIGH>;
+					i2c-parent = <&cam_i2c>;
+					i2c@0 {
+						status = "okay";
+						reg = <0>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+						rbpcv2_imx219_a@10 {
+							status = "disabled";
+						};
+						ar0234_a@10 {
+							reset-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+							compatible = "onsemi,ar0234";
+							reg = <0x10>;
+							devnode = "video0";
+							physical_w = "15.0";
+							physical_h = "12.5";
+							sensor_model = "ar0234";
+							use_sensor_mode_id = "true";
+							mode0 { /* AR0234_MODE_1920X1200_30FPS */
+								mclk_khz = "24000";
+								num_lanes = "2";
+								tegra_sinterface = "serial_b";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								dpcm_enable = "false";
+								cil_settletime = "0";
+								lane_polarity = "6";
+								dynamic_pixel_bit_depth = "10";
+								csi_pixel_bit_depth = "10";
+								mode_type = "bayer";
+								pixel_phase = "grbg";
+								active_w = "1920";
+								active_h = "1200";
+								readout_orientation = "0";
+								line_length = "2448";
+								inherent_gain = "1";
+								mclk_multiplier = "3.01";
+								pix_clk_hz = "134400000";
+								gain_factor = "100";
+								min_gain_val = "100";
+								max_gain_val = "1600";
+								step_gain_val = "1";
+								default_gain = "100";
+								min_hdr_ratio = "1";
+								max_hdr_ratio = "1";
+								framerate_factor = "1000000";
+								min_framerate = "2000000"; /* 2.0 fps */
+								max_framerate = "30000000"; /* 30.0 fps */
+								step_framerate = "1";
+								default_framerate = "30000000"; /* 30.0 fps */
+								exposure_factor = "1000000";
+								min_exp_time = "28"; /* us */
+								max_exp_time = "22000"; /* us */
+								step_exp_time = "1";
+								default_exp_time = "22000"; /* us */
+								embedded_metadata_height = "0";
+							};
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									reg = <0>;
+									ar0234_out0: endpoint {
+										status = "okay";
+										port-index = <1>;
+										bus-width = <2>;
+										remote-endpoint = <&ar0234_csi_in0>;
+									};
+								};
+							};
+						};
+					};
+					i2c@1 {
+						status = "okay";
+						reg = <1>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+						rbpcv2_imx219_c@10 {
+							status = "disabled";
+						};
+						ar0234_c@10 {
+							reset-gpios = <&gpio CAM1_PWDN GPIO_ACTIVE_HIGH>;
+							compatible = "onsemi,ar0234";
+							reg = <0x10>;
+							devnode = "video1";
+							physical_w = "15.0";
+							physical_h = "12.5";
+							sensor_model = "ar0234";
+							use_sensor_mode_id = "true";
+							mode0 { /* AR0234_MODE_1920X1200_30FPS */
+								mclk_khz = "24000";
+								num_lanes = "2";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								dpcm_enable = "false";
+								cil_settletime = "0";
+								lane_polarity = "0";
+								dynamic_pixel_bit_depth = "10";
+								csi_pixel_bit_depth = "10";
+								mode_type = "bayer";
+								pixel_phase = "grbg";
+								active_w = "1920";
+								active_h = "1200";
+								readout_orientation = "0";
+								line_length = "2448";
+								inherent_gain = "1";
+								mclk_multiplier = "3.01";
+								pix_clk_hz = "134400000";
+								gain_factor = "100";
+								min_gain_val = "100";
+								max_gain_val = "1600";
+								step_gain_val = "1";
+								default_gain = "100";
+								min_hdr_ratio = "1";
+								max_hdr_ratio = "1";
+								framerate_factor = "1000000";
+								min_framerate = "2000000"; /* 2.0 fps */
+								max_framerate = "30000000"; /* 30.0 fps */
+								step_framerate = "1";
+								default_framerate = "30000000"; /* 30.0 fps */
+								exposure_factor = "1000000";
+								min_exp_time = "28"; /* us */
+								max_exp_time = "22000"; /* us */
+								step_exp_time = "1";
+								default_exp_time = "22000"; /* us */
+								embedded_metadata_height = "0";
+							};
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									reg = <0>;
+									ar0234_out1: endpoint {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ar0234_csi_in1>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				gpio@6000d000 {
+					camera-control-output-low {
+						gpio-hog;
+						output-low;
+						gpios = <CAM1_PWDN 0  CAM0_PWDN 0>;
+						label = "cam1-pwdn", "cam0-pwdn";
+					};
+				};
+			};
+		};
+	};
+};

--- a/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/Makefile
+++ b/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/Makefile
@@ -60,6 +60,7 @@ dtbo-y += tegra234-p3737-camera-p3762-a00-overlay.dtbo
 dtbo-y += tegra234-p3740-camera-p3783-a00-overlay.dtbo
 dtbo-y += tegra234-p3767-camera-p3768-imx219-C.dtbo
 dtbo-y += tegra234-p3767-camera-p3768-imx219-A.dtbo
+dtbo-y += tegra234-p3767-camera-p3768-ar0234-dual.dtbo
 dtbo-y += ark_i2s_gpio.dtbo
 
 ifneq ($(dtb-y),)

--- a/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ar0234-dual.dts
+++ b/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ar0234-dual.dts
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+/dts-v1/;
+/plugin/;
+
+#define CAM0_PWDN	TEGRA234_MAIN_GPIO(H, 6)
+#define CAM1_PWDN	TEGRA234_MAIN_GPIO(AC, 0)
+#define CAM_I2C_MUX 	TEGRA234_AON_GPIO(CC, 3)
+
+#include <dt-bindings/tegra234-p3767-0000-common.h>
+
+/ {
+	overlay-name = "Camera AR0234 Dual";
+	jetson-header-name = "Jetson 24pin CSI Connector";
+	compatible = JETSON_COMPATIBLE_P3768;
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			tegra-capture-vi {
+				num-channels = <2>;
+				ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+					port@0 {
+						reg = <0>;
+						ar0234_vi_in0: endpoint {
+							port-index = <1>;
+							bus-width = <2>;
+							remote-endpoint = <&ar0234_csi_out0>;
+						};
+					};
+					port@1 {
+						reg = <1>;
+						ar0234_vi_in1: endpoint {
+							port-index = <2>;
+							bus-width = <2>;
+							remote-endpoint = <&ar0234_csi_out1>;
+						};
+					};
+				};
+			};
+			tegra-camera-platform {
+				compatible = "nvidia, tegra-camera-platform";
+				num_csi_lanes = <4>;
+				max_lane_speed = <1500000>;
+				min_bits_per_pixel = <10>;
+				vi_peak_byte_per_pixel = <2>;
+				vi_bw_margin_pct = <25>;
+				max_pixel_rate = <7500000>;
+				isp_peak_byte_per_pixel = <5>;
+				isp_bw_margin_pct = <25>;
+				modules {
+					module0 {
+						badge = "jakku_front_ar0234";
+						position = "front";
+						orientation = "1";
+						drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@0/ar0234_a@10";
+						};
+					};
+					module1 {
+						badge = "jakku_rear_ar0234";
+						position = "rear";
+						orientation = "1";
+						drivernode0 {
+							pcl_id = "v4l2_sensor";
+							sysfs-device-tree = "/sys/firmware/devicetree/base/bus@0/cam_i2cmux/i2c@1/ar0234_c@10";
+						};
+					};
+				};
+			};
+			bus@0 {
+				host1x@13e00000 {
+					nvcsi@15a00000 {
+						num-channels = <2>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+						channel@0 {
+							reg = <0>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									reg = <0>;
+									ar0234_csi_in0: endpoint@0 {
+										port-index = <1>;
+										bus-width = <2>;
+										remote-endpoint = <&ar0234_out0>;
+									};
+								};
+								port@1 {
+									reg = <1>;
+									ar0234_csi_out0: endpoint@1 {
+										remote-endpoint = <&ar0234_vi_in0>;
+									};
+								};
+							};
+						};
+						channel@1 {
+							reg = <1>;
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									reg = <0>;
+									ar0234_csi_in1: endpoint@2 {
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ar0234_out1>;
+									};
+								};
+								port@1 {
+									reg = <1>;
+									ar0234_csi_out1: endpoint@3 {
+										remote-endpoint = <&ar0234_vi_in1>;
+									};
+								};
+							};
+						};
+					};
+				};
+				cam_i2cmux {
+					status = "okay";
+					compatible = "i2c-mux-gpio";
+					#address-cells = <1>;
+					#size-cells = <0>;
+					mux-gpios = <&gpio_aon CAM_I2C_MUX GPIO_ACTIVE_HIGH>;
+					i2c-parent = <&cam_i2c>;
+					i2c@0 {
+						status = "okay";
+						reg = <0>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+						rbpcv2_imx219_a@10 {
+							status = "disabled";
+						};
+						ar0234_a@10 {
+							reset-gpios = <&gpio CAM0_PWDN GPIO_ACTIVE_HIGH>;
+							compatible = "onsemi,ar0234";
+							reg = <0x10>;
+							devnode = "video0";
+							physical_w = "15.0";
+							physical_h = "12.5";
+							sensor_model = "ar0234";
+							use_sensor_mode_id = "true";
+							mode0 { /* AR0234_MODE_1920X1200_30FPS */
+								mclk_khz = "24000";
+								num_lanes = "2";
+								tegra_sinterface = "serial_b";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								dpcm_enable = "false";
+								cil_settletime = "0";
+								lane_polarity = "6";
+								dynamic_pixel_bit_depth = "10";
+								csi_pixel_bit_depth = "10";
+								mode_type = "bayer";
+								pixel_phase = "grbg";
+								active_w = "1920";
+								active_h = "1200";
+								readout_orientation = "0";
+								line_length = "2448";
+								inherent_gain = "1";
+								mclk_multiplier = "3.01";
+								pix_clk_hz = "134400000";
+								gain_factor = "100";
+								min_gain_val = "100";
+								max_gain_val = "1600";
+								step_gain_val = "1";
+								default_gain = "100";
+								min_hdr_ratio = "1";
+								max_hdr_ratio = "1";
+								framerate_factor = "1000000";
+								min_framerate = "2000000"; /* 2.0 fps */
+								max_framerate = "30000000"; /* 30.0 fps */
+								step_framerate = "1";
+								default_framerate = "30000000"; /* 30.0 fps */
+								exposure_factor = "1000000";
+								min_exp_time = "28"; /* us */
+								max_exp_time = "22000"; /* us */
+								step_exp_time = "1";
+								default_exp_time = "22000"; /* us */
+								embedded_metadata_height = "0";
+							};
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									reg = <0>;
+									ar0234_out0: endpoint {
+										status = "okay";
+										port-index = <1>;
+										bus-width = <2>;
+										remote-endpoint = <&ar0234_csi_in0>;
+									};
+								};
+							};
+						};
+					};
+					i2c@1 {
+						status = "okay";
+						reg = <1>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+						rbpcv2_imx219_c@10 {
+							status = "disabled";
+						};
+						ar0234_c@10 {
+							reset-gpios = <&gpio CAM1_PWDN GPIO_ACTIVE_HIGH>;
+							compatible = "onsemi,ar0234";
+							reg = <0x10>;
+							devnode = "video1";
+							physical_w = "15.0";
+							physical_h = "12.5";
+							sensor_model = "ar0234";
+							use_sensor_mode_id = "true";
+							mode0 { /* AR0234_MODE_1920X1200_30FPS */
+								mclk_khz = "24000";
+								num_lanes = "2";
+								tegra_sinterface = "serial_c";
+								phy_mode = "DPHY";
+								discontinuous_clk = "no";
+								dpcm_enable = "false";
+								cil_settletime = "0";
+								lane_polarity = "0";
+								dynamic_pixel_bit_depth = "10";
+								csi_pixel_bit_depth = "10";
+								mode_type = "bayer";
+								pixel_phase = "grbg";
+								active_w = "1920";
+								active_h = "1200";
+								readout_orientation = "0";
+								line_length = "2448";
+								inherent_gain = "1";
+								mclk_multiplier = "3.01";
+								pix_clk_hz = "134400000";
+								gain_factor = "100";
+								min_gain_val = "100";
+								max_gain_val = "1600";
+								step_gain_val = "1";
+								default_gain = "100";
+								min_hdr_ratio = "1";
+								max_hdr_ratio = "1";
+								framerate_factor = "1000000";
+								min_framerate = "2000000"; /* 2.0 fps */
+								max_framerate = "30000000"; /* 30.0 fps */
+								step_framerate = "1";
+								default_framerate = "30000000"; /* 30.0 fps */
+								exposure_factor = "1000000";
+								min_exp_time = "28"; /* us */
+								max_exp_time = "22000"; /* us */
+								step_exp_time = "1";
+								default_exp_time = "22000"; /* us */
+								embedded_metadata_height = "0";
+							};
+							ports {
+								#address-cells = <1>;
+								#size-cells = <0>;
+								port@0 {
+									reg = <0>;
+									ar0234_out1: endpoint {
+										status = "okay";
+										port-index = <2>;
+										bus-width = <2>;
+										remote-endpoint = <&ar0234_csi_in1>;
+									};
+								};
+							};
+						};
+					};
+				};
+
+				gpio@6000d000 {
+					camera-control-output-low {
+						gpio-hog;
+						output-low;
+						gpios = <CAM1_PWDN 0  CAM0_PWDN 0>;
+						label = "cam1-pwdn", "cam0-pwdn";
+					};
+				};
+			};
+		};
+	};
+};


### PR DESCRIPTION
## Summary
- Adds `tegra234-p3767-camera-p3768-ar0234-dual.dts` overlay for JAJ and PAB_V3
- Uses `onsemi,ar0234` driver (nv_ar0234.ko) with p3768 GPIO I2C mux pattern
- Shows as "Camera AR0234 Dual" in `jetson-io` under "Jetson 24pin CSI Connector"
- Modeled after the IMX477 dual overlay, with AR0234 sensor properties from the existing hawk dtsi

## Test plan
- [x] Build JAJ target and verify `tegra234-p3767-camera-p3768-ar0234-dual.dtbo` is in output
- [x] Flash JAJ, confirm "Camera AR0234 Dual" appears in `config-by-hardware.py -l`
- [ ] Apply overlay, connect AR0234 sensor, verify streaming with `v4l2-ctl`