### PR TITLE
feat: add MT76 chipset drivers for better wifi adapter support

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -143,6 +143,15 @@ echo "CONFIG_RTL8187=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
 echo "CONFIG_RTW88=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
 echo "CONFIG_RTW89=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
 
+# MediaTek MT76x2U (MT7612U USB adapter)
+echo "CONFIG_MT76x2U=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
+echo "CONFIG_MT76x2_COMMON=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
+echo "CONFIG_MT76x02_LIB=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
+echo "CONFIG_MT76x02_USB=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
+echo "CONFIG_MT76_USB=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
+echo "CONFIG_MT76_CORE=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
+echo "CONFIG_MT76_LEDS=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
+
 # Bluetooth
 echo "CONFIG_BT_INTEL=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig
 echo "CONFIG_BT_BCM=y" >> kernel/kernel-jammy-src/arch/arm64/configs/defconfig


### PR DESCRIPTION
## feat: Add MT76 Chipset Drivers for Wi-Fi Adapter Support

### Summary

Enables out-of-the-box support for MediaTek MT76-based USB Wi-Fi adapters (e.g. MT7612U) on a fresh kernel flash by appending the required `CONFIG_MT76*` options to the arm64 kernel `defconfig`.

### Changes

- **`setup.sh`**: Adds 7 kernel config entries for the MT76 driver stack:
  - `CONFIG_MT76_CORE` / `CONFIG_MT76_LEDS` — core MT76 framework
  - `CONFIG_MT76_USB` / `CONFIG_MT76x02_USB` / `CONFIG_MT76x02_LIB` — USB transport layer
  - `CONFIG_MT76x2_COMMON` / `CONFIG_MT76x2U` — MT7612U device support

### Motivation

Previously, MT76-based adapters (such as the popular MT7612U dual-band USB adapter) would have required manual kernel reconfiguration after flashing. After much frustration, installing these drivers did not work. So, since they're in the main line kernel this seemed like the move. This brings them in line with the existing Realtek (`RTL8187`, `RTW88`, `RTW89`) adapter support already present in the setup script.

### Testing

- Flashed Jetson PAB V3 with updated `setup.sh` and verified MT76-based USB adapter is detected without additional configuration.
https://www.amazon.com/Network-AWUS036ACM-Long-Range-Wide-Coverage-High-Sensitivity/dp/B08BJS8FXD?tag=ustxtaddt-20
