### PR TITLE
feat: record ark_jetson_kernel commit in flash logs and package

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -28,6 +28,19 @@ done
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec > >(tee "$SCRIPT_DIR/flash.log.txt") 2>&1
 
+# Log ark_jetson_kernel source version so flash.log.txt records exactly
+# which commit built the image being flashed.
+GIT_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
+GIT_DESCRIBE=$(git -C "$SCRIPT_DIR" describe --always --dirty --tags 2>/dev/null || echo "unknown")
+GIT_BRANCH=$(git -C "$SCRIPT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+echo "========================================="
+echo "  ark_jetson_kernel"
+echo "  Date:     $(date -Iseconds)"
+echo "  Branch:   $GIT_BRANCH"
+echo "  Commit:   $GIT_COMMIT"
+echo "  Describe: $GIT_DESCRIBE"
+echo "========================================="
+
 # Pre-flash target confirmation
 LAST_TARGET_FILE="$SCRIPT_DIR/source_build/LAST_BUILT_TARGET"
 if [ -f "$LAST_TARGET_FILE" ]; then

--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -263,6 +263,20 @@ fi
 
 FLASH_DIR=$(dirname "$FLASH_SCRIPT")
 
+# --- Display package build info if present ---
+# generate_flash_package.sh embeds BUILD_INFO.txt at the top of the tarball;
+# printing it here records the source commit in the per-run flash log.
+
+BUILD_INFO=$(sudo find "$EXTRACT_DIR" -maxdepth 3 -name "BUILD_INFO.txt" 2>/dev/null | head -1 || true)
+if [ -n "$BUILD_INFO" ]; then
+    echo ""
+    echo "========================================="
+    echo "  Package build info"
+    echo "========================================="
+    sudo cat "$BUILD_INFO"
+    echo "========================================="
+fi
+
 # --- Wait for Jetson and flash ---
 
 echo ""

--- a/packaging/generate_flash_package.sh
+++ b/packaging/generate_flash_package.sh
@@ -33,6 +33,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 exec > >(tee "$ROOT_DIR/generate_flash_package.log.txt") 2>&1
 
+# Capture ark_jetson_kernel source version so it can be logged here and
+# embedded in the package (see BUILD_INFO.txt below).
+GIT_COMMIT=$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
+GIT_DESCRIBE=$(git -C "$ROOT_DIR" describe --always --dirty --tags 2>/dev/null || echo "unknown")
+GIT_BRANCH=$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE=$(date -Iseconds)
+BUILD_HOST=$(hostname)
+BUILD_USER=$(whoami)
+echo "========================================="
+echo "  ark_jetson_kernel"
+echo "  Date:     $BUILD_DATE"
+echo "  Branch:   $GIT_BRANCH"
+echo "  Commit:   $GIT_COMMIT"
+echo "  Describe: $GIT_DESCRIBE"
+echo "========================================="
+
 # Validate that a kernel has been built
 LAST_TARGET_FILE="$ROOT_DIR/source_build/LAST_BUILT_TARGET"
 if [ ! -f "$LAST_TARGET_FILE" ]; then
@@ -107,6 +123,33 @@ if [ ! -f "$MFI_FILE" ]; then
     ls -la mfi_*.tar.gz 2>/dev/null
     exit 1
 fi
+
+# Embed BUILD_INFO.txt so customers can identify which ark_jetson_kernel
+# commit produced their flash package. tar --append requires an uncompressed
+# archive, so we decompress, append, and recompress.
+BUILD_INFO_DIR=$(mktemp -d)
+cat > "$BUILD_INFO_DIR/BUILD_INFO.txt" << EOF
+ark_jetson_kernel flash package
+===============================
+Build date:    $BUILD_DATE
+Build host:    $BUILD_HOST
+Build user:    $BUILD_USER
+Branch:        $GIT_BRANCH
+Commit:        $GIT_COMMIT
+Describe:      $GIT_DESCRIBE
+
+Target:        $TARGET
+Flash target:  $FLASH_TARGET
+Storage:       $STORAGE ($STORAGE_DEV)
+Package name:  ${PACKAGE_NAME}.tar.gz
+EOF
+
+echo "Embedding BUILD_INFO.txt (decompressing, appending, recompressing — may take a minute)..."
+sudo gunzip "$MFI_FILE"
+MFI_TAR="${MFI_FILE%.gz}"
+sudo tar --append -f "$MFI_TAR" -C "$BUILD_INFO_DIR" BUILD_INFO.txt
+sudo gzip "$MFI_TAR"
+rm -rf "$BUILD_INFO_DIR"
 
 # Move to project root with descriptive name
 OUTPUT_FILE="$ROOT_DIR/${PACKAGE_NAME}.tar.gz"


### PR DESCRIPTION
## Summary

Makes every flashed image traceable to the exact `ark_jetson_kernel` commit that built it.

- `flash.sh` — prints a banner with branch / commit / `git describe --dirty` at the top of `flash.log.txt`.
- `packaging/generate_flash_package.sh` — logs the same banner and embeds `BUILD_INFO.txt` (commit, describe, date, build host/user, target, storage, package name) inside the mfi tarball via `gunzip → tar --append → gzip`. Adds ~30–60 s of recompression time to package generation on large tarballs.
- `packaging/flash_from_package.sh` — after extracting, prints `BUILD_INFO.txt` to the per-run flash log in `~/.ark-jetson-cache/<version>/logs/`, so the customer's log records the source commit.

Packages published before this change won't contain `BUILD_INFO.txt`; `flash_from_package.sh` handles that gracefully (prints nothing and continues). A new package release will need to be generated and uploaded after merge to get the info embedded.