### PR TITLE
docs: remove prebuilt image instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,6 @@ This repository contains instructions and scripts for flashing your Jetson **Ori
 
 **Note:** This has only been tested with Ubuntu 22.04
 
-## Prebuilt Images (Recommended)
-
-Prebuilt flash packages are available on the [Releases page](https://github.com/ARK-Electronics/ark_jetson_kernel/releases). No build tools or kernel source needed:
-
-```
-curl -LO https://github.com/ARK-Electronics/ark_jetson_kernel/releases/latest/download/flash_from_package.sh
-chmod +x flash_from_package.sh
-./flash_from_package.sh
-```
-
-The script downloads the latest release, reassembles if needed, and flashes. See [packaging/](packaging/) for more details.
-
-Each run is logged to `~/.ark-jetson-cache/<version>/logs/flash-<timestamp>.log`. If you're asked to share a flash log for support, grab the most recent file from that directory.
-
 ## Building from Source
 
 If you need to customize the kernel or device tree, clone this repository and follow the steps below.


### PR DESCRIPTION
## Summary

- The 0.0.6 release contains only a PAB_V3 MFI, but `flash_from_package.sh` downloads whatever assets are attached.
- Running the README's prebuilt snippet on a PAB or JAJ board silently flashes PAB_V3 device trees onto non-V3 hardware.
- Delete the section so users fall back to the Building-from-Source flow until the packaging pipeline is fixed.

The fix is on `fix-flash-package-target-selection` (interactive carrier prompt + publish-time verification). Re-add the instructions after that merges and a release ships all three carriers.