### PR TITLE
feat(packaging): multi-target releases with target selection and same-commit verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ This repository contains instructions and scripts for flashing your Jetson **Ori
 
 **Note:** This has only been tested with Ubuntu 22.04
 
+## Prebuilt Images (Recommended)
+
+Prebuilt flash packages are available on the [Releases page](https://github.com/ARK-Electronics/ark_jetson_kernel/releases). No build tools or kernel source needed:
+
+```
+curl -LO https://github.com/ARK-Electronics/ark_jetson_kernel/releases/latest/download/flash_from_package.sh
+chmod +x flash_from_package.sh
+./flash_from_package.sh
+```
+
+The script downloads the release, prompts you for your carrier (PAB / PAB_V3 / JAJ), reassembles the package if split, and flashes. See [packaging/](packaging/) for more details.
+
+Each run is logged to `~/.ark-jetson-cache/<version>/logs/flash-<timestamp>.log`. If you're asked to share a flash log for support, grab the most recent file from that directory.
+
 ## Building from Source
 
 If you need to customize the kernel or device tree, clone this repository and follow the steps below.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -2,17 +2,25 @@
 
 This document covers how to generate self-contained flash packages and publish them to GitHub Releases. Customers can then flash a Jetson without cloning the repo or building from source.
 
+## Carrier targets
+
+`build_kernel.sh` supports three ARK carriers: `PAB`, `PAB_V3`, and `JAJ`. Each produces a different set of device-tree binaries (pinmux, pad voltages, carrier-specific peripherals), so a flash package is only valid for the carrier it was built for. Module SKU (Orin Nano 4GB/8GB, Orin NX 8GB/16GB) is auto-detected at flash time within a given carrier package.
+
+A release must include all three carrier packages. `publish_release.sh` enforces this.
+
 ## Generating a Flash Package
 
-After running `build_kernel.sh`, generate a flash package:
+After running `build_kernel.sh` for a given target, generate its package:
 
 ```
 ./packaging/generate_flash_package.sh
 ```
 
-No Jetson needs to be connected. The package includes DTBs for all module variants (Orin Nano 4GB/8GB, Orin NX 8GB/16GB) — the correct one is selected automatically at flash time.
+The script reads `source_build/LAST_BUILT_TARGET` (written by `build_kernel.sh`) to name the output. No Jetson needs to be connected.
 
-The output is saved to the project root, e.g. `ark-pab-v3-nvme-super.tar.gz`.
+Outputs:
+- `ark-<target>-<storage>[-super].tar.gz` (or `_split/` dir if >2GB) — the MFI
+- `ark-<target>-<storage>[-super].BUILD_INFO.txt` (or `BUILD_INFO.txt` inside the split dir) — sidecar with commit hash, used by `publish_release.sh`
 
 ### Options
 
@@ -35,16 +43,34 @@ If the package is under 2GB, you get a single `.tar.gz`. If it exceeds 2GB (the 
 
 ## Publishing a Release
 
-After generating and testing the flash package:
+Build and generate for each carrier before publishing:
 
 ```
+# 1. PAB
+./build_kernel.sh                     # pick PAB
+./packaging/generate_flash_package.sh
+
+# 2. PAB_V3
+./build_kernel.sh                     # pick PAB_V3
+./packaging/generate_flash_package.sh
+
+# 3. JAJ
+./build_kernel.sh                     # pick JAJ
+./packaging/generate_flash_package.sh
+
+# 4. Publish
 ./packaging/publish_release.sh v1.0.0
 ```
 
-This script:
-1. Creates a git tag and pushes it
-2. Creates a GitHub Release with flashing instructions
-3. Uploads the flash package and `flash_from_package.sh`
+`build_kernel.sh` auto-cleans build artifacts on target switch, so it is safe to cycle through targets in one working tree.
+
+`publish_release.sh`:
+1. Collects every `ark-*.tar.gz` / `ark-*_split/` in the project root
+2. Verifies all three targets (`pab`, `pab-v3`, `jaj`) are present — errors otherwise
+3. Verifies every package's sidecar `BUILD_INFO.txt` reports the same commit hash — errors on mismatch
+4. Creates the git tag and pushes it
+5. Creates a GitHub Release with flashing instructions and the build commit
+6. Uploads every package, every split part, and `flash_from_package.sh`
 
 Requires the [GitHub CLI](https://cli.github.com/) (`gh`). Install with `sudo apt install gh` and authenticate with `gh auth login`.
 
@@ -64,7 +90,9 @@ Or to flash the latest release:
 ./flash_from_package.sh
 ```
 
-The script downloads the package from GitHub Releases, reassembles if split, extracts, waits for a Jetson in recovery mode, and flashes. No build tools or kernel source needed — just an Ubuntu 22.04 host with USB.
+When the release contains multiple carrier packages, the script prompts interactively for which to flash (PAB / PAB_V3 / JAJ). It then downloads only that carrier's assets, reassembles split parts, waits for a Jetson in recovery mode, and flashes. No build tools or kernel source needed — just an Ubuntu 22.04 host with USB.
+
+Each `(version, target)` is cached separately in `~/.ark-jetson-cache/<version>/<target>/` so switching between targets doesn't re-download a target already fetched.
 
 A local `.tar.gz` or split directory can also be passed directly:
 
@@ -75,8 +103,11 @@ A local `.tar.gz` or split directory can also be passed directly:
 ## Workflow Summary
 
 ```
-./build_kernel.sh                              # build the kernel
-./packaging/generate_flash_package.sh          # generate ark-*.tar.gz / _split
-# ... test the package on a Jetson ...
-./packaging/publish_release.sh v1.0.0          # tag, upload to GitHub Releases
+# For each target (PAB, PAB_V3, JAJ):
+./build_kernel.sh                              # pick target
+./packaging/generate_flash_package.sh          # ark-<target>-*.tar.gz + sidecar
+
+# ... test any/all packages on a Jetson ...
+
+./packaging/publish_release.sh v1.0.0          # verify, tag, upload
 ```

--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -4,9 +4,9 @@
 # Downloads the package from GitHub Releases, reassembles if split, and flashes.
 # No build tools or kernel source needed — just a Linux host with USB.
 #
-# Each version is cached independently in ~/.ark-jetson-cache/<version>/ so you
-# can switch between versions without re-downloading. Re-running after a failure
-# picks up where it left off (partial downloads, extractions, etc. are handled).
+# Releases that contain multiple carrier targets (PAB, PAB_V3, JAJ) prompt
+# interactively to pick which one to flash. Each (version, target) is cached
+# independently in ~/.ark-jetson-cache/<version>/<target>/.
 #
 # Usage: ./flash_from_package.sh [version]
 #        ./flash_from_package.sh              # uses latest release
@@ -140,7 +140,54 @@ else
     fi
     echo "Release: $RELEASE_TAG"
 
-    CACHE_DIR="$CACHE_BASE/$RELEASE_TAG"
+    # --- Detect carrier targets in the release ---
+    # Asset filenames are ark-<target>-<storage>[-super].{tar.gz,part.*}. The
+    # target slug follows the same convention as build_kernel.sh's TARGET,
+    # lowercased with underscores replaced by dashes.
+    KNOWN_TARGETS=("pab" "jaj" "pab-v3")
+    TARGETS_IN_RELEASE=()
+    for t in "${KNOWN_TARGETS[@]}"; do
+        if echo "$release_json" | grep -qE "\"name\": *\"ark-$t-(nvme|sdcard)"; then
+            TARGETS_IN_RELEASE+=("$t")
+        fi
+    done
+
+    if [ ${#TARGETS_IN_RELEASE[@]} -eq 0 ]; then
+        echo "ERROR: No ark-<target>-* assets found in release $RELEASE_TAG."
+        echo "Expected at least one of: ${KNOWN_TARGETS[*]}"
+        exit 1
+    fi
+
+    # --- Select target ---
+    if [ ${#TARGETS_IN_RELEASE[@]} -eq 1 ]; then
+        TARGET="${TARGETS_IN_RELEASE[0]}"
+        echo "Target: $TARGET (only target in release)"
+    else
+        echo ""
+        echo "Please select the target platform:"
+        echo -e "\033[3mNote: PAB Rev3 is not the same as PAB_V3. PAB_V3 is a separate product.\033[0m"
+        i=1
+        for t in "${TARGETS_IN_RELEASE[@]}"; do
+            case "$t" in
+                pab)    label="PAB" ;;
+                pab-v3) label="PAB_V3" ;;
+                jaj)    label="JAJ" ;;
+                *)      label="$t" ;;
+            esac
+            echo "$i) $label"
+            i=$((i+1))
+        done
+        read -rp "Enter your choice (1-${#TARGETS_IN_RELEASE[@]}): " choice
+        if ! [[ "$choice" =~ ^[0-9]+$ ]] || \
+           [ "$choice" -lt 1 ] || [ "$choice" -gt "${#TARGETS_IN_RELEASE[@]}" ]; then
+            echo "Invalid choice. Exiting."
+            exit 1
+        fi
+        TARGET="${TARGETS_IN_RELEASE[$((choice-1))]}"
+        echo "Target: $TARGET"
+    fi
+
+    CACHE_DIR="$CACHE_BASE/$RELEASE_TAG/$TARGET"
 fi
 
 EXTRACT_DIR="$CACHE_DIR/extracted"
@@ -207,6 +254,13 @@ else
 
                 # Skip the script itself if attached to the release
                 if [ "$filename" = "flash_from_package.sh" ]; then
+                    continue
+                fi
+
+                # Only download assets matching the selected target. The
+                # storage token (nvme|sdcard) follows the target slug so
+                # pab doesn't spuriously match pab-v3-*.
+                if ! [[ "$filename" =~ ^ark-${TARGET}-(nvme|sdcard) ]]; then
                     continue
                 fi
 

--- a/packaging/generate_flash_package.sh
+++ b/packaging/generate_flash_package.sh
@@ -159,6 +159,26 @@ mv "$MFI_FILE" "$OUTPUT_FILE"
 FILE_SIZE=$(stat -c%s "$OUTPUT_FILE")
 MAX_SIZE=$((2 * 1024 * 1024 * 1024))
 
+# Build the sidecar BUILD_INFO.txt content once; used below alongside tarball or
+# inside split dir. Lets publish_release.sh verify same-commit across targets
+# without decompressing multi-GB tarballs.
+SIDECAR_CONTENT=$(cat << EOF
+ark_jetson_kernel flash package
+===============================
+Build date:    $BUILD_DATE
+Build host:    $BUILD_HOST
+Build user:    $BUILD_USER
+Branch:        $GIT_BRANCH
+Commit:        $GIT_COMMIT
+Describe:      $GIT_DESCRIBE
+
+Target:        $TARGET
+Flash target:  $FLASH_TARGET
+Storage:       $STORAGE ($STORAGE_DEV)
+Package name:  ${PACKAGE_NAME}.tar.gz
+EOF
+)
+
 if [ "$FILE_SIZE" -gt "$MAX_SIZE" ]; then
     echo ""
     echo "Package exceeds 2GB ($(numfmt --to=iec-i --suffix=B "$FILE_SIZE")) — splitting for GitHub Releases..."
@@ -167,6 +187,9 @@ if [ "$FILE_SIZE" -gt "$MAX_SIZE" ]; then
     split -b 1900m "$OUTPUT_FILE" "$SPLIT_DIR/${PACKAGE_NAME}.part."
     SHA256=$(sha256sum "$OUTPUT_FILE" | cut -d' ' -f1)
     rm -f "$OUTPUT_FILE"
+
+    # Sidecar next to split parts
+    echo "$SIDECAR_CONTENT" > "$SPLIT_DIR/BUILD_INFO.txt"
 
     # Create reassembly script
     cat > "$SPLIT_DIR/reassemble.sh" << 'EOF'
@@ -190,6 +213,9 @@ EOF
     echo "  Original SHA256: $SHA256"
     echo "========================================="
 else
+    # Sidecar next to the single tarball
+    echo "$SIDECAR_CONTENT" > "${OUTPUT_FILE%.tar.gz}.BUILD_INFO.txt"
+
     echo ""
     echo "========================================="
     echo "  Flash package generated successfully"

--- a/packaging/publish_release.sh
+++ b/packaging/publish_release.sh
@@ -26,10 +26,13 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RELEASE_FILES=()
+SIDECARS=()  # BUILD_INFO.txt paths for same-commit verification
 
 for f in "$ROOT_DIR"/ark-*.tar.gz; do
     [ -f "$f" ] || continue
     RELEASE_FILES+=("$f")
+    sidecar="${f%.tar.gz}.BUILD_INFO.txt"
+    [ -f "$sidecar" ] && SIDECARS+=("$sidecar")
 done
 
 for d in "$ROOT_DIR"/ark-*_split; do
@@ -38,6 +41,7 @@ for d in "$ROOT_DIR"/ark-*_split; do
         [ -f "$part" ] || continue
         RELEASE_FILES+=("$part")
     done
+    [ -f "$d/BUILD_INFO.txt" ] && SIDECARS+=("$d/BUILD_INFO.txt")
 done
 
 if [ ${#RELEASE_FILES[@]} -eq 0 ]; then
@@ -45,6 +49,55 @@ if [ ${#RELEASE_FILES[@]} -eq 0 ]; then
     echo "Run packaging/generate_flash_package.sh first."
     exit 1
 fi
+
+# --- Verify all three carrier targets are present ---
+# build_kernel.sh supports PAB, PAB_V3, and JAJ. Releases must include all
+# three so flash_from_package.sh can pick the right one.
+REQUIRED_TARGETS=("pab" "jaj" "pab-v3")
+declare -A TARGETS_FOUND=()
+for f in "${RELEASE_FILES[@]}"; do
+    base=$(basename "$f")
+    for t in "${REQUIRED_TARGETS[@]}"; do
+        if [[ "$base" =~ ^ark-$t-(nvme|sdcard) ]]; then
+            TARGETS_FOUND[$t]=1
+            break
+        fi
+    done
+done
+MISSING_TARGETS=()
+for t in "${REQUIRED_TARGETS[@]}"; do
+    [ -z "${TARGETS_FOUND[$t]:-}" ] && MISSING_TARGETS+=("$t")
+done
+if [ ${#MISSING_TARGETS[@]} -gt 0 ]; then
+    echo "ERROR: Missing targets in release: ${MISSING_TARGETS[*]}"
+    echo "For each missing target, run: ./build_kernel.sh (pick target) and ./packaging/generate_flash_package.sh"
+    exit 1
+fi
+
+# --- Verify all packages were built from the same commit ---
+# Reads the sidecar BUILD_INFO.txt files written by generate_flash_package.sh.
+# Catches the case where one target was rebuilt (new commit, uncommitted
+# changes) and the others weren't.
+if [ ${#SIDECARS[@]} -lt ${#REQUIRED_TARGETS[@]} ]; then
+    echo "ERROR: Expected at least ${#REQUIRED_TARGETS[@]} BUILD_INFO.txt sidecar files, found ${#SIDECARS[@]}."
+    echo "Re-run ./packaging/generate_flash_package.sh for any target built before this fix."
+    exit 1
+fi
+UNIQUE_COMMITS=$(for s in "${SIDECARS[@]}"; do awk '/^Commit:/ {print $2}' "$s"; done | sort -u)
+COMMIT_COUNT=$(printf '%s\n' "$UNIQUE_COMMITS" | grep -c .)
+if [ "$COMMIT_COUNT" -ne 1 ]; then
+    echo "ERROR: Packages were built from different commits:"
+    for s in "${SIDECARS[@]}"; do
+        tgt=$(awk '/^Target:/ {print $2}' "$s")
+        cmt=$(awk '/^Commit:/ {print $2}' "$s")
+        echo "  $tgt: $cmt ($(basename "$s"))"
+    done
+    echo ""
+    echo "Rebuild all targets from the same commit before publishing."
+    exit 1
+fi
+BUILD_COMMIT="$UNIQUE_COMMITS"
+echo "All targets built from commit: $BUILD_COMMIT"
 
 # Always include flash_from_package.sh
 if [ -f "$SCRIPT_DIR/flash_from_package.sh" ]; then
@@ -67,6 +120,10 @@ echo "Tagged and pushed: $VERSION"
 # Build release notes
 NOTES="## ARK Carrier Board Image $VERSION
 
+Contains prebuilt flash packages for all three ARK carriers: **PAB**, **PAB_V3**, and **JAJ**. \`flash_from_package.sh\` prompts you to pick one.
+
+Built from commit \`${BUILD_COMMIT}\`.
+
 ### Flashing
 
 Download and run the flash script:
@@ -76,11 +133,11 @@ chmod +x flash_from_package.sh
 ./flash_from_package.sh ${VERSION}
 \`\`\`
 
-The script downloads the package, reassembles it if split, and flashes the Jetson.
+The script downloads the package for your selected carrier, reassembles it if split, and flashes the Jetson.
 
 **Requirements:** Ubuntu 22.04 host with USB connection. Put the Jetson in recovery mode (hold Force Recovery button while powering on) before or during the script — it will wait for detection.
 
-Supports all Orin Nano/NX module variants — the correct DTB is selected automatically at flash time."
+All Orin Nano/NX module variants (4GB/8GB Nano, 8GB/16GB NX) are auto-detected at flash time within the selected carrier's package."
 
 # Create release, then upload files one at a time
 echo ""


### PR DESCRIPTION
## Summary

Before: a release contained one MFI per publish run (based on `LAST_BUILT_TARGET`), and `flash_from_package.sh` blindly downloaded every asset. Result: a PAB_V3-only release (0.0.6) gets flashed onto PAB or JAJ hardware, writing PAB_V3 device trees on non-V3 carriers.

After:
- `flash_from_package.sh` detects which carriers are in the release (`pab`, `pab-v3`, `jaj`), prompts interactively when more than one is present, and downloads only the selected carrier's assets. Each `(version, target)` caches separately under `~/.ark-jetson-cache/<version>/<target>/`.
- `generate_flash_package.sh` writes a sidecar `BUILD_INFO.txt` next to each package so `publish_release.sh` can verify same-commit across targets without decompressing multi-GB tarballs.
- `publish_release.sh` requires all three carriers (pab, pab-v3, jaj) and verifies every sidecar reports the same commit before tagging and uploading. Release notes describe the three-carrier layout and embed the build commit.
- README + `packaging/README.md` updated to document the build → generate cycle per target.

Follow-up to #58 (temporary README removal). Once this lands and a release ships all three carriers, the prebuilt flow is safe again; the second commit here restores the README section with a note about the prompt.