### PR TITLE
feat(bsp): detect and guard against stale BSP across setup/build/flash

### DIFF
--- a/bsp_version.env
+++ b/bsp_version.env
@@ -1,0 +1,26 @@
+# Single source of truth for BSP / toolchain versions and download URLs.
+# Sourced by setup.sh and scripts/check_bsp.sh.
+#
+# To bump the BSP, change EXPECTED_BSP_RELEASE / EXPECTED_BSP_REVISION below.
+# All three L4T URLs derive from these. The toolchain URL is pinned
+# independently because bootlin gcc tracks its own release cadence.
+
+EXPECTED_BSP_RELEASE="R36"
+EXPECTED_BSP_REVISION="4.4"
+
+# NVIDIA URL conventions — derived from the constants above:
+#   release path: r{release_lower}_release_v{revision}    e.g. r36_release_v4.4
+#   archive tag:  r{release_lower}.{revision}             e.g. r36.4.4
+_release_lc=$(echo "$EXPECTED_BSP_RELEASE" | tr '[:upper:]' '[:lower:]')
+_release_path="${_release_lc}_release_v${EXPECTED_BSP_REVISION}"
+_release_tag="${_release_lc}.${EXPECTED_BSP_REVISION}"
+
+# https://developer.nvidia.com/embedded/jetson-linux-archive
+BSP_URL="https://developer.nvidia.com/downloads/embedded/l4t/${_release_path}/release/Jetson_Linux_${_release_tag}_aarch64.tbz2"
+ROOT_FS_URL="https://developer.nvidia.com/downloads/embedded/l4t/${_release_path}/release/Tegra_Linux_Sample-Root-Filesystem_${_release_tag}_aarch64.tbz2"
+PUBLIC_SOURCES_URL="https://developer.nvidia.com/downloads/embedded/l4t/${_release_path}/sources/public_sources.tbz2"
+
+# Bootlin gcc cross-toolchain — pinned to its own r36 release, independent of the L4T patch revision.
+TOOLCHAIN_URL="https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v3.0/toolchain/aarch64--glibc--stable-2022.08-1.tar.bz2"
+
+unset _release_lc _release_path _release_tag

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -4,6 +4,10 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec > >(tee "$SCRIPT_DIR/build.log.txt") 2>&1
 
+# Refuse to build against a missing or stale BSP (points user at ./setup.sh).
+source "$SCRIPT_DIR/scripts/check_bsp.sh"
+require_bsp "$SCRIPT_DIR"
+
 START_TIME=$(date +%s)
 
 sudo -v

--- a/flash.sh
+++ b/flash.sh
@@ -28,6 +28,10 @@ done
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec > >(tee "$SCRIPT_DIR/flash.log.txt") 2>&1
 
+# Refuse to flash a missing or stale BSP (points user at ./setup.sh).
+source "$SCRIPT_DIR/scripts/check_bsp.sh"
+require_bsp "$SCRIPT_DIR"
+
 # Log ark_jetson_kernel source version so flash.log.txt records exactly
 # which commit built the image being flashed.
 GIT_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")

--- a/scripts/check_bsp.sh
+++ b/scripts/check_bsp.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Shared BSP version detection. Source this from setup.sh, build_kernel.sh,
+# and flash.sh — bsp_version.env is the single source of truth for both the
+# expected version and the download URLs.
+
+_check_bsp_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_check_bsp_dir/../bsp_version.env"
+unset _check_bsp_dir
+
+# Reads prebuilt/Linux_for_Tegra/rootfs/etc/nv_tegra_release (NVIDIA writes it
+# during the BSP extract). Sets DETECTED_BSP_RELEASE / DETECTED_BSP_REVISION.
+# Returns: 0 = match, 1 = nothing to detect, 2 = present but wrong version.
+detect_bsp_version() {
+    local repo_dir="$1"
+    local release_file="$repo_dir/prebuilt/Linux_for_Tegra/rootfs/etc/nv_tegra_release"
+    DETECTED_BSP_RELEASE=""
+    DETECTED_BSP_REVISION=""
+
+    if [ ! -f "$release_file" ]; then
+        return 1
+    fi
+
+    # Format: "# R36 (release), REVISION: 4.4, GCID: ..."
+    DETECTED_BSP_RELEASE=$(grep -oE '^# R[0-9]+' "$release_file" | awk '{print $2}')
+    DETECTED_BSP_REVISION=$(grep -oE 'REVISION: [0-9.]+' "$release_file" | awk '{print $2}')
+
+    if [ -z "$DETECTED_BSP_RELEASE" ] || [ -z "$DETECTED_BSP_REVISION" ]; then
+        return 1
+    fi
+
+    if [ "$DETECTED_BSP_RELEASE" = "$EXPECTED_BSP_RELEASE" ] \
+        && [ "$DETECTED_BSP_REVISION" = "$EXPECTED_BSP_REVISION" ]; then
+        return 0
+    fi
+
+    return 2
+}
+
+# Aborts the calling script with a remediation hint if the BSP isn't ready.
+# Use from build_kernel.sh and flash.sh — both require a matching prebuilt/.
+require_bsp() {
+    local repo_dir="$1"
+    detect_bsp_version "$repo_dir"
+    case $? in
+        0)
+            return 0
+            ;;
+        1)
+            echo "ERROR: BSP not set up — prebuilt/ is missing or incomplete."
+            echo "       Expected: ${EXPECTED_BSP_RELEASE}.${EXPECTED_BSP_REVISION}"
+            echo ""
+            echo "Run ./setup.sh to download the BSP."
+            exit 1
+            ;;
+        2)
+            echo "ERROR: BSP version mismatch."
+            echo "       Found:    ${DETECTED_BSP_RELEASE}.${DETECTED_BSP_REVISION}"
+            echo "       Expected: ${EXPECTED_BSP_RELEASE}.${EXPECTED_BSP_REVISION}"
+            echo ""
+            echo "Re-run ./setup.sh to upgrade the BSP."
+            echo "(setup.sh will prompt before deleting your existing prebuilt/ and source_build/)"
+            exit 1
+            ;;
+    esac
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,62 @@
 #!/bin/bash
 
+# Usage: ./setup.sh [--force | -y]
+#   --force, -y   Skip the confirmation prompt before deleting an existing
+#                 prebuilt/ or source_build/ (intended for CI / scripted runs).
+
 # Log output to file while keeping terminal output
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec > >(tee "$SCRIPT_DIR/setup.log.txt") 2>&1
 
-BSP_URL="https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.4/release/Jetson_Linux_r36.4.4_aarch64.tbz2"
-ROOT_FS_URL="https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.4/release/Tegra_Linux_Sample-Root-Filesystem_r36.4.4_aarch64.tbz2"
-PUBLIC_SOURCES_URL="https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v4.4/sources/public_sources.tbz2"
-TOOLCHAIN_URL="https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v3.0/toolchain/aarch64--glibc--stable-2022.08-1.tar.bz2"
+# Pulls in EXPECTED_BSP_*, BSP_URL, ROOT_FS_URL, PUBLIC_SOURCES_URL,
+# TOOLCHAIN_URL, and the detect_bsp_version / require_bsp helpers.
+# bsp_version.env is the single source of truth — edit it to bump versions.
+source "$SCRIPT_DIR/scripts/check_bsp.sh"
+
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force|-y)
+            FORCE=1
+            ;;
+        *)
+            echo "Unknown option: $arg"
+            echo "Usage: ./setup.sh [--force | -y]"
+            exit 1
+            ;;
+    esac
+done
+
+# Confirm before destroying an existing setup. Done before any sudo prompt so
+# an aborting user never has to authenticate. Users may have hand-edited
+# kernel sources under source_build/ and we don't want to silently nuke them.
+if [ -d "$SCRIPT_DIR/prebuilt" ] || [ -d "$SCRIPT_DIR/source_build" ]; then
+    detect_bsp_version "$SCRIPT_DIR"
+    case $? in
+        0)
+            echo "Existing setup detected: BSP ${DETECTED_BSP_RELEASE}.${DETECTED_BSP_REVISION} (matches expected)."
+            ;;
+        2)
+            echo "Existing setup detected: BSP ${DETECTED_BSP_RELEASE}.${DETECTED_BSP_REVISION}"
+            echo "  This repo now requires:  BSP ${EXPECTED_BSP_RELEASE}.${EXPECTED_BSP_REVISION}"
+            ;;
+        1)
+            echo "Existing prebuilt/ or source_build/ detected (incomplete or unrecognized BSP version)."
+            ;;
+    esac
+    echo ""
+    echo "Re-running setup will DELETE prebuilt/ and source_build/ and re-download ~5GB."
+    echo "Any local edits in those directories will be lost."
+    if [ $FORCE -eq 0 ]; then
+        read -p "Continue? (y/N): " confirm
+        if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+            echo "Setup aborted."
+            exit 0
+        fi
+    else
+        echo "(--force specified, proceeding without confirmation)"
+    fi
+fi
 
 function cleanup() {
 	kill -9 $SUDO_PID
@@ -57,6 +106,36 @@ export ARK_JETSON_KERNEL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export L4T_RELEASE_PACKAGE=$(basename $BSP_URL)
 export SAMPLE_FS_PACKAGE=$(basename $ROOT_FS_URL)
 export BOARD="jetson-orin-nano-devkit-super"
+
+# If a previous setup is present, summarize it and confirm before deletion —
+# users may have hand-edited kernel sources under source_build/.
+if [ -d "$SCRIPT_DIR/prebuilt" ] || [ -d "$SCRIPT_DIR/source_build" ]; then
+    detect_bsp_version "$SCRIPT_DIR"
+    case $? in
+        0)
+            echo "Existing setup detected: BSP ${DETECTED_BSP_RELEASE}.${DETECTED_BSP_REVISION} (matches expected)."
+            ;;
+        2)
+            echo "Existing setup detected: BSP ${DETECTED_BSP_RELEASE}.${DETECTED_BSP_REVISION}"
+            echo "  This repo now requires:  BSP ${EXPECTED_BSP_RELEASE}.${EXPECTED_BSP_REVISION}"
+            ;;
+        1)
+            echo "Existing prebuilt/ or source_build/ detected (incomplete or unrecognized BSP version)."
+            ;;
+    esac
+    echo ""
+    echo "Re-running setup will DELETE prebuilt/ and source_build/ and re-download ~5GB."
+    echo "Any local edits in those directories will be lost."
+    if [ $FORCE -eq 0 ]; then
+        read -p "Continue? (y/N): " confirm
+        if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+            echo "Setup aborted."
+            exit 0
+        fi
+    else
+        echo "(--force specified, proceeding without confirmation)"
+    fi
+fi
 
 # remove previous
 sudo rm -rf source_build


### PR DESCRIPTION
## Summary
Add a single source of truth for the expected JetPack BSP version and make `setup.sh`, `build_kernel.sh`, and `flash.sh` detect and respond to stale or missing prebuilt artifacts.

## Problem
- `setup.sh` did a silent `sudo rm -rf prebuilt/ source_build/` on every re-run, destroying any in-place kernel-source edits without warning. Long-time users with stale R35 clones had no signal that their setup needed an upgrade.
- `build_kernel.sh` and `flash.sh` did not validate the BSP version, so a stale install would fail mid-build with cryptic errors instead of pointing the user back at `setup.sh`.
- The expected version was implicit in hardcoded URLs in `setup.sh`, with no mechanism to compare against what was actually installed.

## Solution
- Single source of truth in `bsp_version.env` for the expected BSP version and the L4T download URLs — both derive from one pair of constants, so a version bump is a one-line edit.
- `setup.sh` detects existing setup via `nv_tegra_release`, reports the version, and confirms before deletion. The prompt runs *before* any `sudo` call, so an aborting user never has to authenticate. `--force` / `-y` is available for scripted runs.
- `build_kernel.sh` and `flash.sh` fail fast with a one-line "run `./setup.sh`" message on missing or mismatched BSP.

Design choice: detection is automatic, only destruction asks for consent. Silent multi-GB `rm -rf` is a worse footgun than a one-keystroke `y/N` prompt.