### PR TITLE
feat(build): auto-containerize on non-22.04 hosts + add CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build kernel
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache bootlin toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/l4t-gcc
+          key: l4t-gcc-${{ hashFiles('bsp_version.env') }}
+
+      - name: Setup BSP
+        run: ./setup.sh --force
+
+      - name: Build kernel for PAB
+        run: ./build_kernel.sh PAB
+
+      - name: Upload kernel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-PAB
+          path: prebuilt/Linux_for_Tegra/kernel/
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This repository contains instructions and scripts for flashing your Jetson **Ori
 | Kernel | Linux 5.15 |
 | Host OS | Ubuntu 22.04 |
 
+> **Building on a non-22.04 host?** `setup.sh` and `build_kernel.sh` auto-containerize themselves in a 22.04 docker image (docker is auto-installed via apt if missing). See [docs/build_host.md](docs/build_host.md) for why we pin to 22.04.
+
 ## Building from Source
 
 If you need to customize the kernel or device tree, clone this repository and follow the steps below.
@@ -22,9 +24,10 @@ The script will configure the default user, password, and hostname as `jetson`.
 ```
 
 ### 2. Build
-Once the setup script is finished you can build the kernel.
+Once the setup script is finished you can build the kernel. Pass the target platform as an argument, or run with no argument for an interactive prompt.
 ```
-./build_kernel.sh
+./build_kernel.sh           # interactive prompt
+./build_kernel.sh PAB_V3    # non-interactive: PAB | JAJ | PAB_V3
 ```
 
 ### 3. Add WiFi (optional)

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -1,49 +1,67 @@
 #!/bin/bash
 
-# Log output to file while keeping terminal output
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec > >(tee "$SCRIPT_DIR/build.log.txt") 2>&1
+export ARK_JETSON_KERNEL_DIR="$SCRIPT_DIR"
+
+# Auto-containerize on hosts other than Ubuntu 22.04. See docs/build_host.md.
+source "$SCRIPT_DIR/scripts/container_runner.sh"
+
+# Log output to file while keeping terminal output. Skip when re-execing into
+# the build container — the in-container run will tee the same bind-mounted
+# file itself, and overlapping tees would garble the log.
+if ! needs_container; then
+    exec > >(tee "$SCRIPT_DIR/build.log.txt") 2>&1
+fi
 
 # Refuse to build against a missing or stale BSP (points user at ./setup.sh).
 source "$SCRIPT_DIR/scripts/check_bsp.sh"
 require_bsp "$SCRIPT_DIR"
 
+# Target selection. Accept positional arg (PAB | JAJ | PAB_V3) for CI/scripted
+# use; fall back to interactive prompt for human shells. Done on the host
+# before any container handoff so the in-container pass always sees the arg.
+if [ -n "$1" ]; then
+    case "$1" in
+        PAB|JAJ|PAB_V3) TARGET="$1" ;;
+        *)
+            echo "Invalid target: $1. Must be PAB, JAJ, or PAB_V3." >&2
+            exit 1
+            ;;
+    esac
+elif [ -t 0 ]; then
+    echo "Please select the target platform:"
+    echo -e "\033[3mNote: PAB Rev3 is not the same as PAB_V3. PAB_V3 is a separate product.\033[0m"
+    echo "1) PAB"
+    echo "2) JAJ"
+    echo "3) PAB_V3"
+    read -p "Enter your choice (1, 2, or 3): " choice
+    case $choice in
+        1) TARGET="PAB" ;;
+        2) TARGET="JAJ" ;;
+        3) TARGET="PAB_V3" ;;
+        *) echo "Invalid choice. Exiting."; exit 1 ;;
+    esac
+else
+    echo "ERROR: target required (PAB | JAJ | PAB_V3) when running non-interactively." >&2
+    echo "Usage: $0 [PAB | JAJ | PAB_V3]" >&2
+    exit 1
+fi
+DT_SOURCE="ark_$(echo "$TARGET" | tr '[:upper:]' '[:lower:]')"
+export TARGET
+
+# Re-exec inside the 22.04 build container if needed. Does not return.
+if needs_container; then
+    run_in_container "$0" "$TARGET"
+fi
+
 START_TIME=$(date +%s)
 
 sudo -v
-export ARK_JETSON_KERNEL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export CROSS_COMPILE=$HOME/l4t-gcc/aarch64--glibc--stable-2022.08-1/bin/aarch64-buildroot-linux-gnu-
 export KERNEL_HEADERS=$ARK_JETSON_KERNEL_DIR/source_build/Linux_for_Tegra/source/kernel/kernel-jammy-src
 export INSTALL_MOD_PATH=$ARK_JETSON_KERNEL_DIR/prebuilt/Linux_for_Tegra/rootfs/
 
 pushd .
-
-# Interactive selection for target platform
-echo "Please select the target platform:"
-echo -e "\033[3mNote: PAB Rev3 is not the same as PAB_V3. PAB_V3 is a separate product.\033[0m"
-echo "1) PAB"
-echo "2) JAJ"
-echo "3) PAB_V3"
-read -p "Enter your choice (1, 2, or 3): " choice
-
-case $choice in
-    1)
-        export TARGET="PAB"
-        DT_SOURCE="ark_pab"
-        ;;
-    2)
-        export TARGET="JAJ"
-        DT_SOURCE="ark_jaj"
-        ;;
-    3)
-        export TARGET="PAB_V3"
-        DT_SOURCE="ark_pab_v3"
-        ;;
-    *)
-        echo "Invalid choice. Exiting."
-        exit 1
-        ;;
-esac
 
 # Auto-clean on target switch to prevent stale build artifacts
 LAST_TARGET_FILE="$ARK_JETSON_KERNEL_DIR/source_build/LAST_BUILT_TARGET"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+# Build environment matching NVIDIA's documented host for L4T R36.4.4 / JP 6.2.1.
+# See docs/build_host.md for why we pin to 22.04 (kmod 29 in the Jetson sample
+# rootfs cannot parse kmod 31's modules.builtin index format).
+
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        flex \
+        bison \
+        libssl-dev \
+        bc \
+        kmod \
+        wget \
+        tar \
+        bzip2 \
+        cpio \
+        sudo \
+        git \
+        python3 \
+        ca-certificates \
+        rsync \
+        xxd \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/docs/build_host.md
+++ b/docs/build_host.md
@@ -1,0 +1,81 @@
+# Build Host Environment
+
+## Required host
+
+NVIDIA's documented build host for L4T R36.4.4 / JetPack 6.2.1 is **Ubuntu 22.04** (or 20.04). This repo's `setup.sh` and `build_kernel.sh` enforce that:
+
+- On Ubuntu 22.04 they run natively.
+- On any other host they re-exec themselves inside a 22.04 docker container (`ark-jetson-builder:22.04`, built from `docker/Dockerfile` on first use).
+- If docker is missing on a non-22.04 host, the scripts auto-install it via `apt-get install -y docker.io` (requires sudo). On non-apt distros they hard-fail with a pointer to this document.
+- If the current user isn't in the `docker` group, the wrapper falls back to `sudo docker` so the build works without forcing a logout/relogin to pick up the new group. Add yourself to the `docker` group later if you'd rather avoid the per-invocation sudo: `sudo usermod -aG docker $USER` then re-login.
+
+The repo bind-mounts itself into the container at `/workspace` and the bootlin cross-toolchain at `/root/l4t-gcc`, so build artifacts (`prebuilt/`, `source_build/`) and the toolchain persist on the host across container runs.
+
+`flash.sh` always runs on the host — it transfers already-built artifacts to the device over USB and gains nothing from containerization.
+
+## Why 22.04 specifically — the kmod incompatibility
+
+The proximate reason is a binary-format incompatibility between `kmod` versions on the host and on the device.
+
+| Where | OS | `kmod` version |
+| --- | --- | --- |
+| Build host (NVIDIA's documented config) | Ubuntu 22.04 | 29 |
+| Build host (current Ubuntu LTS) | Ubuntu 24.04 | 31 |
+| Jetson device (L4T R36.4.4 sample rootfs) | Ubuntu 22.04 | 29 |
+
+`make modules_install` (and NVIDIA's `apply_binaries.sh`) runs the **host's** `depmod` to populate `/lib/modules/$(uname -r)/` in the staged rootfs. `depmod` writes both a text `modules.builtin` file and a set of binary index files (`modules.builtin.bin`, `modules.builtin.alias.bin`, `modules.builtin.modinfo`) that `modprobe` consults at runtime.
+
+Between kmod 29 and kmod 31 the binary-index format changed. When a kmod-31 host writes those indexes, the kmod-29 `modprobe` on the booted Jetson cannot parse them and falls through to "module not found" — even for modules that are correctly listed in the text `modules.builtin` and built into the running kernel.
+
+### Symptom
+
+The first symptom we hit was the `nv-l4t-usb-device-mode` service failing to bind the USB gadget on first boot, killing USB-RNDIS reachability on the PAB and PAB_V3:
+
+```
+$ sudo modprobe -v loop
+modprobe: FATAL: Module loop not found in directory /lib/modules/5.15.148-tegra
+$ echo $?
+1
+```
+
+Despite:
+
+- `CONFIG_BLK_DEV_LOOP=y` in the running kernel (`zcat /proc/config.gz | grep BLK_DEV_LOOP`).
+- `/dev/loop0` existing and `/proc/devices` listing `7 loop`.
+- `/lib/modules/5.15.148-tegra/modules.builtin` containing the line `kernel/drivers/block/loop.ko`.
+- All four binary index files (`modules.builtin{,.bin,.alias.bin,.modinfo}`) present with sizes matching the host-staged copy.
+
+The exit-1 from `modprobe` aborts `nv-l4t-usb-device-mode-start.sh` at line 172 (it runs under `set -e`), so the composite gadget never binds and the host PC sees no USB device when the cable is plugged in. The same failure mode silently affects every other service that probes a built-in module on the device.
+
+### Why containerize instead of patching around it
+
+Three alternatives we considered:
+
+1. **Patch `nv-l4t-usb-device-mode-start.sh` to `modprobe loop || true`.** Masks this one symptom; every other built-in `modprobe` call on the device still fails silently.
+2. **Run `depmod -a` on the device on first boot.** Rewrites the indexes in the device's native kmod-29 format. Works, but adds boot latency and on-device startup ordering complexity for what is fundamentally a build-host bug.
+3. **Strip the binary indexes after `make modules_install`** so `modprobe` falls back to text. Effective, but a workaround masking that we're building on an unsupported host.
+
+Containerization addresses the root cause and matches NVIDIA's documented support. It also keeps the build reproducible across developer machines and CI without each contributor having to maintain a 22.04 host or VM.
+
+## CI
+
+GitHub Actions has a native `ubuntu-22.04` runner, so CI runs the build natively without involving the container at all. See `.github/workflows/build.yml`. The bootlin toolchain is cached across runs keyed on `bsp_version.env`'s hash; the BSP/rootfs/sources tarballs (~5GB extracted) are re-fetched each run because `setup.sh` is destructive — caching them would require a more invasive `setup.sh` refactor.
+
+## Verifying a healthy build
+
+After flashing, on the Jetson:
+
+```bash
+sudo modprobe -v loop; echo "exit=$?"        # expect: no output, exit=0
+ls /dev/loop0                                  # expect: /dev/loop0
+systemctl is-active nv-l4t-usb-device-mode    # expect: active
+```
+
+From the host PC, after plugging the USB-C cable in:
+
+```bash
+ip a | grep -A1 enx                           # expect: USB-RNDIS interface up
+ssh jetson@jetson.local                       # expect: connects
+```
+
+If `modprobe -v loop` returns "Module loop not found in directory ..." while the text `modules.builtin` lists `loop.ko`, you are looking at the kmod-format mismatch described above and the build was almost certainly produced on a non-22.04 host without the container wrapper.

--- a/docs/build_host.md
+++ b/docs/build_host.md
@@ -11,6 +11,8 @@ NVIDIA's documented build host for L4T R36.4.4 / JetPack 6.2.1 is **Ubuntu 22.04
 
 The repo bind-mounts itself into the container at `/workspace` and the bootlin cross-toolchain at `/root/l4t-gcc`, so build artifacts (`prebuilt/`, `source_build/`) and the toolchain persist on the host across container runs.
 
+The container runs as root, so everything it writes through the bind mounts (`prebuilt/`, `source_build/`, `~/l4t-gcc`) ends up `root`-owned on the host. The same is partially true of a native-22.04 build (`apply_binaries.sh` and friends `sudo`-write a lot of `prebuilt/`), so the practical impact is the same: use `sudo rm -rf` if you want to wipe `prebuilt/` or `source_build/` by hand. `setup.sh --force` already does this for you.
+
 `flash.sh` always runs on the host — it transfers already-built artifacts to the device over USB and gains nothing from containerization.
 
 ## Why 22.04 specifically — the kmod incompatibility

--- a/scripts/container_runner.sh
+++ b/scripts/container_runner.sh
@@ -33,7 +33,19 @@ ensure_docker() {
         echo "Docker not installed — installing via apt (requires sudo)..."
         sudo apt-get update
         sudo apt-get install -y docker.io
-        # apt should start dockerd via systemd post-install, but be defensive.
+    fi
+
+    # Quick path: daemon is reachable without sudo and we're done.
+    if docker info >/dev/null 2>&1; then
+        DOCKER_CMD=(docker)
+        return
+    fi
+
+    # Probe failed — either the daemon is stopped or the user isn't in the
+    # docker group. Try starting the daemon first (covers a fresh apt install
+    # and the "installed but service stopped" case); then re-probe and fall
+    # back to sudo docker if the only remaining issue is group membership.
+    if command -v systemctl >/dev/null 2>&1; then
         sudo systemctl is-active docker >/dev/null 2>&1 || sudo systemctl start docker
     fi
 
@@ -69,13 +81,23 @@ run_in_container() {
 
     mkdir -p "$HOME/l4t-gcc"
     echo "Re-executing $(basename "$script_path") in 22.04 build container..."
+
+    # Only request a TTY when our own stdin and stdout are terminals — `docker
+    # run -t` against a non-TTY fd (CI, output redirection, a pipe) errors
+    # with "the input device is not a TTY" before the build can start. `-i`
+    # stays unconditional so the interactive prompt still works from a shell.
+    local tty_flags=(-i)
+    if [ -t 0 ] && [ -t 1 ]; then
+        tty_flags+=(-t)
+    fi
+
     # SYS_ADMIN + apparmor=unconfined: NVIDIA's l4t_create_default_user.sh and
     # other rootfs-customization helpers chroot into the staged rootfs and
     # mount-bind /proc, /sys, /dev. Docker's default seccomp/AppArmor profile
     # blocks mount(2), so we relax both for the build container. The container
     # is ephemeral (--rm) and runs only the kernel build, so the broader
     # privilege scope is acceptable.
-    exec "${DOCKER_CMD[@]}" run --rm -it \
+    exec "${DOCKER_CMD[@]}" run --rm "${tty_flags[@]}" \
         --cap-add=SYS_ADMIN \
         --security-opt apparmor=unconfined \
         -v "$repo_dir:/workspace" \

--- a/scripts/container_runner.sh
+++ b/scripts/container_runner.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Shared host-detection + container-handoff helpers. Sourced by setup.sh and
+# build_kernel.sh. NVIDIA's documented build host for L4T R36.4.4 / JP 6.2.1
+# is Ubuntu 22.04; on anything else we re-exec the calling script inside a
+# 22.04 docker container so that host-tooling differences (notably kmod 31
+# vs kmod 29 in the on-device sample rootfs) cannot silently corrupt the
+# build. See docs/build_host.md for the full background.
+
+ARK_BUILDER_IMAGE="ark-jetson-builder:22.04"
+
+# Returns 0 if the calling script should re-exec inside the build container.
+# False when already inside (IN_BUILD_CONTAINER=1) or when the host is 22.04.
+needs_container() {
+    [ -z "$IN_BUILD_CONTAINER" ] || return 1
+    local host_id
+    host_id=$(. /etc/os-release && echo "$VERSION_ID")
+    [ "$host_id" != "22.04" ]
+}
+
+# Installs docker via apt if it isn't on PATH, then sets DOCKER_CMD to either
+# (docker) or (sudo docker) depending on whether the current user can talk to
+# the docker daemon without sudo. The sudo fallback avoids forcing the user
+# to add themselves to the docker group + re-login the first time they run.
+# Exits on failure.
+ensure_docker() {
+    if ! command -v docker >/dev/null 2>&1; then
+        if ! command -v apt-get >/dev/null 2>&1; then
+            echo "ERROR: docker is not installed and apt-get is not available." >&2
+            echo "       Install docker manually, or run on an Ubuntu 22.04 host." >&2
+            echo "       See docs/build_host.md." >&2
+            exit 1
+        fi
+        echo "Docker not installed — installing via apt (requires sudo)..."
+        sudo apt-get update
+        sudo apt-get install -y docker.io
+        # apt should start dockerd via systemd post-install, but be defensive.
+        sudo systemctl is-active docker >/dev/null 2>&1 || sudo systemctl start docker
+    fi
+
+    if docker info >/dev/null 2>&1; then
+        DOCKER_CMD=(docker)
+    else
+        DOCKER_CMD=(sudo docker)
+    fi
+}
+
+# Re-exec the calling script inside the 22.04 build container. Does not
+# return on success. Builds the image on first use. Bind-mounts the repo
+# at /workspace and the bootlin toolchain at /root/l4t-gcc.
+#
+# Args:
+#   $1     path to the calling script ($0)
+#   $2..   args to pass through to the in-container invocation
+run_in_container() {
+    local script_path="$1"; shift
+    local repo_dir="$ARK_JETSON_KERNEL_DIR"
+
+    if [ -z "$repo_dir" ]; then
+        echo "ERROR: ARK_JETSON_KERNEL_DIR is not set; cannot bind-mount repo into container." >&2
+        exit 1
+    fi
+
+    ensure_docker
+
+    if ! "${DOCKER_CMD[@]}" image inspect "$ARK_BUILDER_IMAGE" >/dev/null 2>&1; then
+        echo "Building $ARK_BUILDER_IMAGE (one-time, ~30-60s)..."
+        "${DOCKER_CMD[@]}" build -t "$ARK_BUILDER_IMAGE" "$repo_dir/docker/"
+    fi
+
+    mkdir -p "$HOME/l4t-gcc"
+    echo "Re-executing $(basename "$script_path") in 22.04 build container..."
+    # SYS_ADMIN + apparmor=unconfined: NVIDIA's l4t_create_default_user.sh and
+    # other rootfs-customization helpers chroot into the staged rootfs and
+    # mount-bind /proc, /sys, /dev. Docker's default seccomp/AppArmor profile
+    # blocks mount(2), so we relax both for the build container. The container
+    # is ephemeral (--rm) and runs only the kernel build, so the broader
+    # privilege scope is acceptable.
+    exec "${DOCKER_CMD[@]}" run --rm -it \
+        --cap-add=SYS_ADMIN \
+        --security-opt apparmor=unconfined \
+        -v "$repo_dir:/workspace" \
+        -v "$HOME/l4t-gcc:/root/l4t-gcc" \
+        -w /workspace \
+        -e IN_BUILD_CONTAINER=1 \
+        "$ARK_BUILDER_IMAGE" \
+        bash "/workspace/$(basename "$script_path")" "$@"
+}

--- a/setup.sh
+++ b/setup.sh
@@ -251,7 +251,7 @@ mkdir -p $HOME/l4t-gcc
 cd $HOME/l4t-gcc
 
 TOOLCHAIN_FILENAME=$(basename "$TOOLCHAIN_URL")
-TOOLCHAIN_DIRNAME=${FILENAME%.bz2}
+TOOLCHAIN_DIRNAME=${TOOLCHAIN_FILENAME%.tar.bz2}
 
 if [ ! -f "$TOOLCHAIN_FILENAME" ]; then
 	echo "Downloading Jetson bootlin toolchain"

--- a/setup.sh
+++ b/setup.sh
@@ -152,6 +152,19 @@ sudo Linux_for_Tegra/tools/l4t_flash_prerequisites.sh
 # Fresh systems could be missing these packages
 sudo apt-get install make build-essential flex bison libssl-dev -y
 
+# Force-register the qemu-aarch64 binfmt handler in the kernel. binfmt-support
+# normally does this via its init script, but in the docker container the
+# postinst's `invoke-rc.d binfmt-support start` is denied by the base image's
+# policy-rc.d (Debian convention: containers don't run init, so service starts
+# are forbidden during package config). Without registration the kernel can't
+# route aarch64 ELFs through qemu-user-static, and apply_binaries.sh's
+# chroot+dpkg fails with "Exec format error". Hosts with qemu-user-static
+# already installed natively (binfmt_misc is kernel-global) hit the early-out.
+if [ ! -e /proc/sys/fs/binfmt_misc/qemu-aarch64 ]; then
+    echo "Registering qemu-aarch64 binfmt handler"
+    sudo update-binfmts --enable qemu-aarch64
+fi
+
 echo "Applying binaries"
 sudo Linux_for_Tegra/apply_binaries.sh --debug
 

--- a/setup.sh
+++ b/setup.sh
@@ -74,9 +74,16 @@ if needs_container; then
     run_in_container "$0" "$@"
 fi
 
+# Fail fast on any error past this point. Above this line is an interactive
+# `read -p` whose EOF would trip set -e; below is automated work where any
+# silent failure (e.g. a partial apply_binaries.sh) leaves the rootfs broken
+# and the user later hits "BSP not set up" from build_kernel.sh.
+set -e -o pipefail
+
 function cleanup() {
-	kill -9 $SUDO_PID
-	exit 0
+	if [ -n "${SUDO_PID:-}" ]; then
+		kill -9 "$SUDO_PID" 2>/dev/null || true
+	fi
 }
 
 function sudo_refresh_loop() {
@@ -110,7 +117,7 @@ function download_with_retry() {
 	fi
 }
 
-trap cleanup SIGINT SIGTERM
+trap cleanup EXIT
 
 # keep sudo credentials alive in the background
 sudo -v
@@ -251,9 +258,31 @@ popd
 
 popd
 
+# Sanity-check that the staged BSP is actually present and the right version.
+# Catches the silent-failure mode where an earlier step partially succeeded
+# but left the rootfs incomplete — without this, "Setup complete" would print
+# and the user would only discover the problem when build_kernel.sh fails.
+# Capture rc via `|| rc=$?` so detect_bsp_version's non-zero returns don't
+# trip set -e before we reach the case dispatch.
+bsp_rc=0
+detect_bsp_version "$SCRIPT_DIR" || bsp_rc=$?
+case $bsp_rc in
+	0) ;;
+	1)
+		echo "ERROR: setup finished but prebuilt/Linux_for_Tegra/rootfs/etc/nv_tegra_release"
+		echo "       is missing. Some earlier step in setup.sh failed silently."
+		echo "       Review setup.log.txt for the underlying error."
+		exit 1
+		;;
+	2)
+		echo "ERROR: staged BSP version mismatch."
+		echo "       Found:    ${DETECTED_BSP_RELEASE}.${DETECTED_BSP_REVISION}"
+		echo "       Expected: ${EXPECTED_BSP_RELEASE}.${EXPECTED_BSP_REVISION}"
+		exit 1
+		;;
+esac
+
 END_TIME=$(date +%s)
 TOTAL_TIME=$((${END_TIME}-${START_TIME}))
 echo "Setup complete in $(date -d@${TOTAL_TIME} -u +%H:%M:%S)"
 echo "You can now build the kernel with ./build_kernel.sh"
-
-cleanup

--- a/setup.sh
+++ b/setup.sh
@@ -4,14 +4,23 @@
 #   --force, -y   Skip the confirmation prompt before deleting an existing
 #                 prebuilt/ or source_build/ (intended for CI / scripted runs).
 
-# Log output to file while keeping terminal output
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec > >(tee "$SCRIPT_DIR/setup.log.txt") 2>&1
+export ARK_JETSON_KERNEL_DIR="$SCRIPT_DIR"
 
 # Pulls in EXPECTED_BSP_*, BSP_URL, ROOT_FS_URL, PUBLIC_SOURCES_URL,
 # TOOLCHAIN_URL, and the detect_bsp_version / require_bsp helpers.
 # bsp_version.env is the single source of truth — edit it to bump versions.
 source "$SCRIPT_DIR/scripts/check_bsp.sh"
+
+# Auto-containerize on hosts other than Ubuntu 22.04. See docs/build_host.md.
+source "$SCRIPT_DIR/scripts/container_runner.sh"
+
+# Log output to file while keeping terminal output. Skip when re-execing into
+# the build container — the in-container run will tee the same bind-mounted
+# file itself, and overlapping tees would garble the log.
+if ! needs_container; then
+    exec > >(tee "$SCRIPT_DIR/setup.log.txt") 2>&1
+fi
 
 FORCE=0
 for arg in "$@"; do
@@ -30,7 +39,9 @@ done
 # Confirm before destroying an existing setup. Done before any sudo prompt so
 # an aborting user never has to authenticate. Users may have hand-edited
 # kernel sources under source_build/ and we don't want to silently nuke them.
-if [ -d "$SCRIPT_DIR/prebuilt" ] || [ -d "$SCRIPT_DIR/source_build" ]; then
+# Skipped inside the build container — the host pass already confirmed.
+if [ -z "$IN_BUILD_CONTAINER" ] && \
+   ([ -d "$SCRIPT_DIR/prebuilt" ] || [ -d "$SCRIPT_DIR/source_build" ]); then
     detect_bsp_version "$SCRIPT_DIR"
     case $? in
         0)
@@ -56,6 +67,11 @@ if [ -d "$SCRIPT_DIR/prebuilt" ] || [ -d "$SCRIPT_DIR/source_build" ]; then
     else
         echo "(--force specified, proceeding without confirmation)"
     fi
+fi
+
+# Re-exec inside the 22.04 build container if needed. Does not return.
+if needs_container; then
+    run_in_container "$0" "$@"
 fi
 
 function cleanup() {
@@ -102,40 +118,9 @@ sudo_refresh_loop &
 SUDO_PID=$!
 START_TIME=$(date +%s)
 
-export ARK_JETSON_KERNEL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export L4T_RELEASE_PACKAGE=$(basename $BSP_URL)
 export SAMPLE_FS_PACKAGE=$(basename $ROOT_FS_URL)
 export BOARD="jetson-orin-nano-devkit-super"
-
-# If a previous setup is present, summarize it and confirm before deletion —
-# users may have hand-edited kernel sources under source_build/.
-if [ -d "$SCRIPT_DIR/prebuilt" ] || [ -d "$SCRIPT_DIR/source_build" ]; then
-    detect_bsp_version "$SCRIPT_DIR"
-    case $? in
-        0)
-            echo "Existing setup detected: BSP ${DETECTED_BSP_RELEASE}.${DETECTED_BSP_REVISION} (matches expected)."
-            ;;
-        2)
-            echo "Existing setup detected: BSP ${DETECTED_BSP_RELEASE}.${DETECTED_BSP_REVISION}"
-            echo "  This repo now requires:  BSP ${EXPECTED_BSP_RELEASE}.${EXPECTED_BSP_REVISION}"
-            ;;
-        1)
-            echo "Existing prebuilt/ or source_build/ detected (incomplete or unrecognized BSP version)."
-            ;;
-    esac
-    echo ""
-    echo "Re-running setup will DELETE prebuilt/ and source_build/ and re-download ~5GB."
-    echo "Any local edits in those directories will be lost."
-    if [ $FORCE -eq 0 ]; then
-        read -p "Continue? (y/N): " confirm
-        if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
-            echo "Setup aborted."
-            exit 0
-        fi
-    else
-        echo "(--force specified, proceeding without confirmation)"
-    fi
-fi
 
 # remove previous
 sudo rm -rf source_build


### PR DESCRIPTION
## Summary

setup.sh and build_kernel.sh now containerize themselves in a 22.04 build image when run on any other host (docker auto-installed via apt if missing). Adds CI on ubuntu-22.04 runners and `docs/build_host.md` on the kmod-31 build-host incompatibility that drove the change.

## Problem

Building on Ubuntu 24.04 silently corrupts the rootfs: host kmod 31 writes binary module-index files (`modules.builtin.bin`, `modules.builtin.alias.bin`) in a format the on-device kmod 29 (jammy sample-rootfs) can't parse. Result: `modprobe` returns "module not found" for every built-in module — most visibly `nv-l4t-usb-device-mode-start.sh` failing at `modprobe loop` and breaking USB-RNDIS reachability on first boot. NVIDIA only supports 20.04/22.04 hosts for L4T R36.4.4. See `docs/build_host.md` for the full breakdown.

## Solution

`scripts/container_runner.sh` wraps both setup.sh and build_kernel.sh: detects host OS, builds + caches the docker image on first use, re-execs the calling script inside the container with `--cap-add=SYS_ADMIN --security-opt apparmor=unconfined` (needed by L4T helpers that chroot+mount the staged rootfs). Falls back to `sudo docker` if the user isn't in the docker group, avoiding a forced logout/relogin. build_kernel.sh accepts a positional target arg (PAB | JAJ | PAB_V3) for CI/scripted use; interactive prompt preserved for human shells. CI builds on the native ubuntu-22.04 runner and caches the bootlin toolchain by `bsp_version.env` hash.