### PR TITLE
fix(camera): map imx219-A overlay to CSI port A for PAB_V3 J28

### DIFF
--- a/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-A.dts
+++ b/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-A.dts
@@ -28,7 +28,7 @@
 					vi_port0: port@0 {
 						reg = <0>;
 						rbpcv2_imx219_vi_in0: endpoint {
-							port-index = <1>;
+							port-index = <0>;
 							bus-width = <2>;
 							remote-endpoint = <&rbpcv2_imx219_csi_out0>;
 						};
@@ -110,7 +110,7 @@
 								csi_chan0_port0: port@0 {
 									reg = <0>;
 									rbpcv2_imx219_csi_in0: endpoint@0 {
-										port-index = <1>;
+										port-index = <0>;
 										bus-width = <2>;
 										remote-endpoint = <&rbpcv2_imx219_out0>;
 									};
@@ -233,7 +233,7 @@
 							mode0 { /* IMX219_MODE_3280x2464_21FPS */
 								mclk_khz = "24000";
 								num_lanes = "2";
-								tegra_sinterface = "serial_b";
+								tegra_sinterface = "serial_a";
 								lane_polarity = "6";
 								phy_mode = "DPHY";
 								discontinuous_clk = "yes";
@@ -271,7 +271,7 @@
 							mode1 { /* IMX219_MODE_3280x1848_28FPS */
 								mclk_khz = "24000";
 								num_lanes = "2";
-								tegra_sinterface = "serial_b";
+								tegra_sinterface = "serial_a";
 								lane_polarity = "6";
 								phy_mode = "DPHY";
 								discontinuous_clk = "yes";
@@ -309,7 +309,7 @@
 							mode2 { /* IMX219_MODE_1920x1080_30FPS */
 								mclk_khz = "24000";
 								num_lanes = "2";
-								tegra_sinterface = "serial_b";
+								tegra_sinterface = "serial_a";
 								lane_polarity = "6";
 								phy_mode = "DPHY";
 								discontinuous_clk = "yes";
@@ -347,7 +347,7 @@
 							mode3 { /* IMX219_MODE_1640x1232_30FPS */
 								mclk_khz = "24000";
 								num_lanes = "2";
-								tegra_sinterface = "serial_b";
+								tegra_sinterface = "serial_a";
 								lane_polarity = "6";
 								phy_mode = "DPHY";
 								discontinuous_clk = "yes";
@@ -385,7 +385,7 @@
 							mode4 { /* IMX219_MODE_1280x720_60FPS */
 								mclk_khz = "24000";
 								num_lanes = "2";
-								tegra_sinterface = "serial_b";
+								tegra_sinterface = "serial_a";
 								lane_polarity = "6";
 								phy_mode = "DPHY";
 								discontinuous_clk = "yes";
@@ -427,7 +427,7 @@
 									reg = <0>;
 									rbpcv2_imx219_out0: endpoint {
 										status = "okay";
-										port-index = <1>;
+										port-index = <0>;
 										bus-width = <2>;
 										remote-endpoint = <&rbpcv2_imx219_csi_in0>;
 									};


### PR DESCRIPTION
## Summary

Make the stock `imx219-A` overlay actually work on PAB_V3's Camera1 (J28) connector. Verified on bench: i2c enumerates at `0x10` on bus 10 (mux LOW → HSD1 → J28), `/dev/video*` appears, sensor streams.

## Problem

The overlay was inherited from the Orin Nano dev kit, where the CAM1 connector terminates on NVCSI port B. PAB_V3 wires its J28 connector through SoM pins `CSI0_*` instead, so the lanes land on NVCSI port A. The stock `port-index = <1>` / `tegra_sinterface = "serial_b"` therefore associate the sensor with the wrong NVCSI brick — i2c can detect the chip (via the unrelated cam_i2cmux path), but VI/CSI never receives frames.

## Solution

Retarget the overlay's three CSI endpoints (VI input, NVCSI input, sensor output) and all five mode entries to NVCSI port A:

- `port-index`: `1` → `0`
- `tegra_sinterface`: `"serial_b"` → `"serial_a"`

`reset-gpios` (`CAM0_PWDN` = PH.06) and `lane_polarity = "6"` are kept — both match PAB_V3's J28 wiring.