### PR TITLE
fix(camera): map imx219 dual overlay cam A to CSI port A for PAB_V3

### DIFF
--- a/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-camera-rbpcv2-imx219.dtsi
+++ b/device_tree/ark_pab_v3/Linux_for_Tegra/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-camera-rbpcv2-imx219.dtsi
@@ -16,7 +16,7 @@
 					vi_port0: port@0 {
 						reg = <0>;
 						rbpcv2_imx219_vi_in0: endpoint {
-							port-index = <1>;
+							port-index = <0>;
 							bus-width = <2>;
 							remote-endpoint = <&rbpcv2_imx219_csi_out0>;
 						};
@@ -46,7 +46,7 @@
 								csi_chan0_port0: port@0 {
 									reg = <0>;
 									rbpcv2_imx219_csi_in0: endpoint@0 {
-										port-index = <1>;
+										port-index = <0>;
 										bus-width = <2>;
 										remote-endpoint = <&rbpcv2_imx219_out0>;
 									};
@@ -179,7 +179,7 @@
 							mode0 { /* IMX219_MODE_3280x2464_21FPS */
 								mclk_khz = "24000";
 								num_lanes = "2";
-								tegra_sinterface = "serial_b";
+								tegra_sinterface = "serial_a";
 								lane_polarity = "6";
 								phy_mode = "DPHY";
 								discontinuous_clk = "yes";
@@ -217,7 +217,7 @@
 							mode1 { /* IMX219_MODE_3280x1848_28FPS */
 								mclk_khz = "24000";
 								num_lanes = "2";
-								tegra_sinterface = "serial_b";
+								tegra_sinterface = "serial_a";
 								lane_polarity = "6";
 								phy_mode = "DPHY";
 								discontinuous_clk = "yes";
@@ -255,7 +255,7 @@
 							mode2 { /* IMX219_MODE_1920x1080_30FPS */
 								mclk_khz = "24000";
 								num_lanes = "2";
-								tegra_sinterface = "serial_b";
+								tegra_sinterface = "serial_a";
 								lane_polarity = "6";
 								phy_mode = "DPHY";
 								discontinuous_clk = "yes";
@@ -293,7 +293,7 @@
 							mode3 { /* IMX219_MODE_1640x1232_30FPS */
 								mclk_khz = "24000";
 								num_lanes = "2";
-								tegra_sinterface = "serial_b";
+								tegra_sinterface = "serial_a";
 								lane_polarity = "6";
 								phy_mode = "DPHY";
 								discontinuous_clk = "yes";
@@ -331,7 +331,7 @@
 							mode4 { /* IMX219_MODE_1280x720_60FPS */
 								mclk_khz = "24000";
 								num_lanes = "2";
-								tegra_sinterface = "serial_b";
+								tegra_sinterface = "serial_a";
 								lane_polarity = "6";
 								phy_mode = "DPHY";
 								discontinuous_clk = "yes";
@@ -372,7 +372,7 @@
 								port@0 {
 									reg = <0>;
 									rbpcv2_imx219_out0: endpoint {
-										port-index = <1>;
+										port-index = <0>;
 										bus-width = <2>;
 										remote-endpoint = <&rbpcv2_imx219_csi_in0>;
 									};


### PR DESCRIPTION
## Summary

Mirror the cam-A port-A remap from #65 inside the shared `tegra234-camera-rbpcv2-imx219.dtsi` so the dual overlay also lands cam A on NVCSI port A for PAB_V3. Cam C is unchanged (port C / J29 matches the single C overlay).

## Problem

The single A overlay was fixed in 2975dfd, but the dual overlay was still broken because it `#include`s `tegra234-camera-rbpcv2-imx219.dtsi`, which still carries the Orin Nano dev-kit layout — cam A on NVCSI port B (`port-index = 1` / `tegra_sinterface = "serial_b"`). On PAB_V3 the J28 connector routes through SoM pins `CSI0_*`, which terminate on NVCSI port A, so the dual build never bound cam A to a working brick. The single A and C overlays are self-contained and weren't affected; only the PAB_V3 copy of the dtsi is touched here, so `ark_pab` (dev-kit) is untouched.

## Solution

In `device_tree/ark_pab_v3/.../tegra234-camera-rbpcv2-imx219.dtsi` only, retarget the cam-A side onto NVCSI port A — same shape as 2975dfd:

- `port-index`: `1` -> `0` in the VI input, the NVCSI channel-0 input, and the sensor output endpoint
- `tegra_sinterface`: `"serial_b"` -> `"serial_a"` in all five `rbpcv2_imx219_a@10` mode nodes

Validated by preprocessing + `dtc -@ -I dts -O dtb` on the dual overlay: dtbo builds cleanly and the warning set is identical to the pre-fix build.