### PR TITLE
feat(ci): per-product release pipeline with tag-driven CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: true
           android: true
@@ -98,6 +98,11 @@ jobs:
               [ -f "$part" ] && RELEASE_FILES+=("$part")
             done
           done
+          if [ ${#RELEASE_FILES[@]} -eq 0 ]; then
+            echo "::error::No flash package artifacts found (ark-*.tar.gz or ark-*_split/)"
+            exit 1
+          fi
+
           RELEASE_FILES+=("packaging/flash_from_package.sh")
 
           echo "Release assets:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,9 +126,5 @@ jobs:
 
           gh release create "$TAG" \
             --title "${PRODUCT_UPPER} v${VERSION}" \
-            --notes-file /tmp/release-notes.md
-
-          for f in "${RELEASE_FILES[@]}"; do
-            echo "Uploading $(basename "$f")..."
-            gh release upload "$TAG" "$f"
-          done
+            --notes-file /tmp/release-notes.md \
+            "${RELEASE_FILES[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,134 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'pab-[0-9]*'
+      - 'jaj-[0-9]*'
+      - 'pab-v3-[0-9]*'
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    permissions:
+      contents: write
+
+    steps:
+      - name: Parse tag
+        id: parse
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          case "$TAG" in
+            pab-v3-*) PRODUCT="pab-v3"; VERSION="${TAG#pab-v3-}"; TARGET="PAB_V3" ;;
+            pab-*)    PRODUCT="pab";    VERSION="${TAG#pab-}";    TARGET="PAB" ;;
+            jaj-*)    PRODUCT="jaj";    VERSION="${TAG#jaj-}";    TARGET="JAJ" ;;
+            *) echo "::error::Unrecognized tag format: $TAG"; exit 1 ;;
+          esac
+          echo "product=$PRODUCT" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "Parsed tag: product=$PRODUCT version=$VERSION target=$TARGET"
+
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
+      - name: Install flash prerequisites
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y \
+            abootimg binfmt-support binutils cpio cpp curl \
+            device-tree-compiler dosfstools \
+            iproute2 iputils-ping lbzip2 libxml2-utils lz4 \
+            netcat-openbsd nfs-kernel-server openssl \
+            python3-yaml qemu-user-static rsync sshpass \
+            udev usbutils uuid-runtime whois xmlstarlet zstd
+
+      - name: Cache bootlin toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/l4t-gcc
+          key: l4t-gcc-${{ hashFiles('bsp_version.env') }}
+
+      - name: Setup BSP
+        run: ./setup.sh --force
+
+      - name: Build kernel
+        run: ./build_kernel.sh ${{ steps.parse.outputs.target }}
+
+      - name: Generate flash package
+        run: ./packaging/generate_flash_package.sh
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          PRODUCT="${{ steps.parse.outputs.product }}"
+          VERSION="${{ steps.parse.outputs.version }}"
+          TARGET="${{ steps.parse.outputs.target }}"
+
+          source bsp_version.env
+          L4T_VERSION="${EXPECTED_BSP_RELEASE}.${EXPECTED_BSP_REVISION}"
+
+          PRODUCT_UPPER=$(echo "$PRODUCT" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+
+          # Collect release assets
+          RELEASE_FILES=()
+          for f in ark-*.tar.gz; do
+            [ -f "$f" ] && RELEASE_FILES+=("$f")
+          done
+          for d in ark-*_split; do
+            [ -d "$d" ] || continue
+            for part in "$d"/*.part.*; do
+              [ -f "$part" ] && RELEASE_FILES+=("$part")
+            done
+          done
+          RELEASE_FILES+=("packaging/flash_from_package.sh")
+
+          echo "Release assets:"
+          for f in "${RELEASE_FILES[@]}"; do
+            echo "  $(basename "$f") ($(du -h "$f" | cut -f1))"
+          done
+
+          COMMIT_SHORT=$(git rev-parse --short HEAD)
+          REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
+
+          cat > /tmp/release-notes.md <<EOF
+          ## ${PRODUCT_UPPER} v${VERSION}
+
+          L4T ${L4T_VERSION} (Jetpack ${JETPACK_VERSION}) | Built from \`${COMMIT_SHORT}\`
+
+          ### Flash
+
+          \`\`\`
+          curl -LO ${REPO_URL}/releases/download/${TAG}/flash_from_package.sh
+          chmod +x flash_from_package.sh
+          ./flash_from_package.sh ${TAG}
+          \`\`\`
+
+          Put the Jetson in recovery mode before running. Requires Ubuntu 22.04 host with USB connection. Supports all Orin Nano/NX module variants.
+          EOF
+
+          gh release create "$TAG" \
+            --title "${PRODUCT_UPPER} v${VERSION}" \
+            --notes-file /tmp/release-notes.md
+
+          for f in "${RELEASE_FILES[@]}"; do
+            echo "Uploading $(basename "$f")..."
+            gh release upload "$TAG" "$f"
+          done

--- a/README.md
+++ b/README.md
@@ -11,6 +11,26 @@ This repository contains instructions and scripts for flashing your Jetson **Ori
 
 > **Building on a non-22.04 host?** `setup.sh` and `build_kernel.sh` auto-containerize themselves in a 22.04 docker image (docker is auto-installed via apt if missing). See [docs/build_host.md](docs/build_host.md) for why we pin to 22.04.
 
+## Prebuilt Images (Recommended)
+
+Flash a Jetson without building from source. Download and run the flash script for your carrier board:
+
+```
+curl -LO https://github.com/ARK-Electronics/ark_jetson_kernel/releases/download/<tag>/flash_from_package.sh
+chmod +x flash_from_package.sh
+./flash_from_package.sh <tag>
+```
+
+Replace `<tag>` with a release tag for your product (e.g. `pab-6.2.1.1`, `jaj-6.2.1.1`, `pab-v3-6.2.1.1`). Or pass just the product name to flash the latest release:
+
+```
+./flash_from_package.sh pab       # latest PAB release
+./flash_from_package.sh jaj       # latest JAJ release
+./flash_from_package.sh pab-v3    # latest PAB_V3 release
+```
+
+Requires Ubuntu 22.04 host with USB connection. Put the Jetson in recovery mode before running. See [Releases](https://github.com/ARK-Electronics/ark_jetson_kernel/releases) for available versions.
+
 ## Building from Source
 
 If you need to customize the kernel or device tree, clone this repository and follow the steps below.

--- a/bsp_version.env
+++ b/bsp_version.env
@@ -8,6 +8,10 @@
 EXPECTED_BSP_RELEASE="R36"
 EXPECTED_BSP_REVISION="4.4"
 
+# Jetpack marketing version — not derivable from L4T version numbers.
+# Update this when bumping the BSP.
+JETPACK_VERSION="6.2.1"
+
 # NVIDIA URL conventions — derived from the constants above:
 #   release path: r{release_lower}_release_v{revision}    e.g. r36_release_v4.4
 #   archive tag:  r{release_lower}.{revision}             e.g. r36.4.4

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,10 +1,63 @@
 # Flash Package Generation & Distribution
 
-This document covers how to generate self-contained flash packages and publish them to GitHub Releases. Customers can then flash a Jetson without cloning the repo or building from source.
+This document covers how flash packages are generated, released, and consumed. Each release targets a single carrier board product.
 
-## Generating a Flash Package
+## Carrier Targets
 
-After running `build_kernel.sh`, generate a flash package:
+| Target | Product | Tag prefix |
+|--------|---------|------------|
+| PAB | ARK Jetson PAB Carrier | `pab-` |
+| JAJ | ARK Just a Jetson Carrier | `jaj-` |
+| PAB_V3 | ARK Jetson PAB V3 Carrier | `pab-v3-` |
+
+Each carrier has its own device tree. A flash package built for one carrier will not work on another.
+
+> **Note:** PAB Rev3 is not the same as PAB_V3. PAB_V3 is a separate product.
+
+## Releasing
+
+Releases are driven by git tags. Push a tag matching `{product}-{version}` and CI builds the flash package and creates a GitHub Release automatically.
+
+### Tag format
+
+`{product}-{jetpack_version}.{ark_revision}` — for example `pab-6.2.1.1`.
+
+- The Jetpack version (`6.2.1`) comes from NVIDIA's Jetpack release.
+- The ARK revision (`.1`) is incremented for each ARK release on that Jetpack version.
+- Each product versions independently.
+
+### Creating a release
+
+Build the kernel for your target, then tag and push:
+
+```
+./build_kernel.sh PAB
+./packaging/publish_release.sh 6.2.1.1    # creates tag pab-6.2.1.1 and pushes
+```
+
+Or tag manually:
+
+```
+git tag -a pab-6.2.1.1 -m "pab-6.2.1.1"
+git push origin pab-6.2.1.1
+```
+
+CI will build the kernel, generate the flash package, and publish the release. Monitor progress at https://github.com/ARK-Electronics/ark_jetson_kernel/actions.
+
+### Releasing all products at the same version
+
+When a change affects all carriers, push a tag for each:
+
+```
+git tag -a pab-6.2.1.1 -m "pab-6.2.1.1"
+git tag -a jaj-6.2.1.1 -m "jaj-6.2.1.1"
+git tag -a pab-v3-6.2.1.1 -m "pab-v3-6.2.1.1"
+git push origin pab-6.2.1.1 jaj-6.2.1.1 pab-v3-6.2.1.1
+```
+
+## Generating a Flash Package (local)
+
+After running `build_kernel.sh`, generate a flash package locally:
 
 ```
 ./packaging/generate_flash_package.sh
@@ -12,7 +65,7 @@ After running `build_kernel.sh`, generate a flash package:
 
 No Jetson needs to be connected. The package includes DTBs for all module variants (Orin Nano 4GB/8GB, Orin NX 8GB/16GB) — the correct one is selected automatically at flash time.
 
-The output is saved to the project root, e.g. `ark-pab-v3-nvme-super.tar.gz`.
+The output is saved to the project root, e.g. `ark-pab-nvme-super.tar.gz`.
 
 ### Options
 
@@ -21,62 +74,24 @@ The output is saved to the project root, e.g. `ark-pab-v3-nvme-super.tar.gz`.
 | `--sdcard` | Generate a package for SD card instead of NVMe |
 | `--no-super` | Target the non-super module variant |
 
-```
-# Generate for SD card
-./packaging/generate_flash_package.sh --sdcard
+If the package exceeds 2GB (the GitHub Releases per-file limit), it is automatically split into 1.9GB parts in a `_split/` directory.
 
-# Non-super module variant
-./packaging/generate_flash_package.sh --no-super
-```
+## Flashing from a Release (customer)
 
-### Output
-
-If the package is under 2GB, you get a single `.tar.gz`. If it exceeds 2GB (the GitHub Releases per-file limit), it is automatically split into 1.9GB parts in a `_split/` directory.
-
-## Publishing a Release
-
-After generating and testing the flash package:
+Download and run the flash script:
 
 ```
-./packaging/publish_release.sh v1.0.0
-```
-
-This script:
-1. Creates a git tag and pushes it
-2. Creates a GitHub Release with flashing instructions
-3. Uploads the flash package and `flash_from_package.sh`
-
-Requires the [GitHub CLI](https://cli.github.com/) (`gh`). Install with `sudo apt install gh` and authenticate with `gh auth login`.
-
-## Flashing from a Package (Customer)
-
-Customers download and run the flash script — it handles everything:
-
-```
-curl -LO https://github.com/ARK-Electronics/ark_jetson_kernel/releases/download/<version>/flash_from_package.sh
+curl -LO https://github.com/ARK-Electronics/ark_jetson_kernel/releases/download/pab-6.2.1.1/flash_from_package.sh
 chmod +x flash_from_package.sh
-./flash_from_package.sh <version>
+./flash_from_package.sh pab-6.2.1.1
 ```
 
-Or to flash the latest release:
+Or flash the latest release for a product:
 
 ```
-./flash_from_package.sh
+./flash_from_package.sh pab
 ```
 
-The script downloads the package from GitHub Releases, reassembles if split, extracts, waits for a Jetson in recovery mode, and flashes. No build tools or kernel source needed — just an Ubuntu 22.04 host with USB.
+The script downloads the package, extracts it, waits for a Jetson in recovery mode, and flashes. No build tools or kernel source needed — just an Ubuntu 22.04 host with USB.
 
-A local `.tar.gz` or split directory can also be passed directly:
-
-```
-./flash_from_package.sh ark-pab-v3-nvme-super.tar.gz
-```
-
-## Workflow Summary
-
-```
-./build_kernel.sh                              # build the kernel
-./packaging/generate_flash_package.sh          # generate ark-*.tar.gz / _split
-# ... test the package on a Jetson ...
-./packaging/publish_release.sh v1.0.0          # tag, upload to GitHub Releases
-```
+Each version is cached in `~/.ark-jetson-cache/<tag>/` so re-running after a failure or switching between versions doesn't re-download.

--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -95,7 +95,7 @@ RELEASE_TAG=""
 
 if is_product_name "$INPUT"; then
     echo "Finding latest $INPUT release..."
-    releases_json=$(curl -sL "${API_URL}?per_page=50")
+    releases_json=$(curl -sfL "${API_URL}?per_page=100")
 
     RELEASE_TAG=$(echo "$releases_json" \
         | grep -o '"tag_name": *"[^"]*"' \
@@ -157,7 +157,7 @@ else
         echo "Using cached download: $(basename "$TARBALL")"
     else
         echo "Fetching release $RELEASE_TAG..."
-        release_json=$(curl -sL "$API_URL/tags/$RELEASE_TAG")
+        release_json=$(curl -sfL "$API_URL/tags/$RELEASE_TAG")
 
         if echo "$release_json" | grep -q '"message"'; then
             msg=$(echo "$release_json" | grep -o '"message": *"[^"]*"' | head -1)
@@ -191,7 +191,7 @@ else
             fi
 
             echo "  Downloading $filename..."
-            curl -L --progress-bar -o "$CACHE_DIR/$filename.tmp" "$url"
+            curl -fL --progress-bar -o "$CACHE_DIR/$filename.tmp" "$url"
             mv "$CACHE_DIR/$filename.tmp" "$CACHE_DIR/$filename"
         done <<< "$assets"
         echo ""

--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -100,11 +100,9 @@ if is_product_name "$INPUT"; then
     RELEASE_TAG=$(echo "$releases_json" \
         | grep -o '"tag_name": *"[^"]*"' \
         | sed 's/"tag_name": *"//;s/"//' \
-        | while read -r tag; do
-            case "$tag" in
-                ${INPUT}-[0-9]*) echo "$tag"; break ;;
-            esac
-        done)
+        | grep "^${INPUT}-[0-9]" \
+        | sort -V \
+        | tail -1)
 
     if [ -z "$RELEASE_TAG" ]; then
         echo "ERROR: No releases found for product '$INPUT'"

--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -157,7 +157,7 @@ else
         echo "Using cached download: $(basename "$TARBALL")"
     else
         echo "Fetching release $RELEASE_TAG..."
-        release_json=$(curl -sfL "$API_URL/tags/$RELEASE_TAG")
+        release_json=$(curl -sL "$API_URL/tags/$RELEASE_TAG")
 
         if echo "$release_json" | grep -q '"message"'; then
             msg=$(echo "$release_json" | grep -o '"message": *"[^"]*"' | head -1)

--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
 
 # Flash a Jetson from a prebuilt ARK flash package.
-# Downloads the package from GitHub Releases, reassembles if split, and flashes.
-# No build tools or kernel source needed — just a Linux host with USB.
+# Downloads the package from GitHub Releases and flashes.
 #
-# Each version is cached independently in ~/.ark-jetson-cache/<version>/ so you
-# can switch between versions without re-downloading. Re-running after a failure
-# picks up where it left off (partial downloads, extractions, etc. are handled).
-#
-# Usage: ./flash_from_package.sh [version]
-#        ./flash_from_package.sh              # uses latest release
-#        ./flash_from_package.sh 0.0.6        # specific version
-#        ./flash_from_package.sh package.tar.gz  # local file
-#        ./flash_from_package.sh --clean       # remove all cached data
+# Usage:
+#   ./flash_from_package.sh <tag>        # specific release (e.g. pab-6.2.1.1)
+#   ./flash_from_package.sh <product>    # latest release for a product (pab, jaj, pab-v3)
+#   ./flash_from_package.sh --clean      # remove all cached data
 
 set -euo pipefail
 
@@ -20,14 +14,33 @@ REPO="ARK-Electronics/ark_jetson_kernel"
 API_URL="https://api.github.com/repos/$REPO/releases"
 CACHE_BASE="$HOME/.ark-jetson-cache"
 
-# --- Handle --help / --clean ---
+usage() {
+    echo "Usage: $(basename "$0") <tag|product>"
+    echo ""
+    echo "  $(basename "$0") pab-6.2.1.1    Flash a specific release"
+    echo "  $(basename "$0") pab             Flash the latest PAB release"
+    echo "  $(basename "$0") jaj             Flash the latest JAJ release"
+    echo "  $(basename "$0") pab-v3          Flash the latest PAB_V3 release"
+    echo "  $(basename "$0") --clean         Remove all cached data"
+    echo ""
+    echo "Note: PAB Rev3 is not the same as PAB_V3. PAB_V3 is a separate product."
+    exit 1
+}
 
-if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
-    sed -n '2,/^$/{ s/^# \?//; p }' "$0"
-    exit 0
+is_product_name() {
+    case "$1" in
+        pab|jaj|pab-v3) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# --- Handle no args / --help / --clean ---
+
+if [ $# -eq 0 ] || [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    usage
 fi
 
-if [ "${1:-}" = "--clean" ]; then
+if [ "$1" = "--clean" ]; then
     if [ -d "$CACHE_BASE" ]; then
         echo "Removing cached data in $CACHE_BASE ..."
         sudo rm -rf "$CACHE_BASE"
@@ -51,8 +64,7 @@ else
     echo "WARNING: Could not detect Ubuntu version. Ubuntu 22.04+ is required."
 fi
 
-# --- Install prerequisites (skip if already installed) ---
-# These packages are required by l4t_initrd_flash.sh (from NVIDIA's l4t_flash_prerequisites.sh)
+# --- Install prerequisites ---
 
 FLASH_PREREQS=(abootimg binfmt-support binutils cpio cpp curl
     device-tree-compiler dosfstools
@@ -76,85 +88,48 @@ else
     echo "All prerequisites installed."
 fi
 
-# --- Determine input and cache directory ---
+# --- Resolve input to a release tag ---
 
-INPUT="${1:-}"
-TARBALL=""
-CACHE_DIR=""
-NEED_DOWNLOAD=false
+INPUT="$1"
+RELEASE_TAG=""
 
-if [ -n "$INPUT" ] && [ -f "$INPUT" ]; then
-    # Local tarball
-    TARBALL="$(realpath "$INPUT")"
-    CACHE_DIR="$CACHE_BASE/local-$(basename "$INPUT" .tar.gz)"
-    echo "Using local tarball: $TARBALL"
+if is_product_name "$INPUT"; then
+    echo "Finding latest $INPUT release..."
+    releases_json=$(curl -sL "${API_URL}?per_page=50")
 
-elif [ -n "$INPUT" ] && [ -d "$INPUT" ]; then
-    # Local directory with split parts
-    local_dir="$(realpath "$INPUT")"
-    CACHE_DIR="$CACHE_BASE/local-$(basename "$INPUT")"
-    TARBALL="$CACHE_DIR/package.tar.gz"
+    RELEASE_TAG=$(echo "$releases_json" \
+        | grep -o '"tag_name": *"[^"]*"' \
+        | sed 's/"tag_name": *"//;s/"//' \
+        | while read -r tag; do
+            case "$tag" in
+                ${INPUT}-[0-9]*) echo "$tag"; break ;;
+            esac
+        done)
 
-    if [ ! -f "$TARBALL" ]; then
-        if ls "$local_dir"/*.part.* &>/dev/null; then
-            mkdir -p "$CACHE_DIR"
-            echo "Reassembling split parts from $local_dir..."
-            cat "$local_dir"/*.part.* > "$TARBALL.tmp"
-            mv "$TARBALL.tmp" "$TARBALL"
-            echo "Reassembled: $TARBALL"
-        else
-            echo "ERROR: No split parts found in $local_dir"
-            exit 1
-        fi
-    else
-        echo "Using cached reassembled tarball."
-    fi
-
-else
-    # GitHub release
-    NEED_DOWNLOAD=true
-
-    if [ -z "$INPUT" ]; then
-        echo "Fetching latest release..."
-        release_url="$API_URL/latest"
-    else
-        echo "Fetching release $INPUT..."
-        release_url="$API_URL/tags/$INPUT"
-    fi
-
-    release_json=$(curl -sL "$release_url")
-
-    if echo "$release_json" | grep -q '"message"'; then
-        msg=$(echo "$release_json" | grep -o '"message": *"[^"]*"' | head -1)
-        echo "ERROR: Release not found ($msg)"
+    if [ -z "$RELEASE_TAG" ]; then
+        echo "ERROR: No releases found for product '$INPUT'"
         echo ""
         echo "Available releases:"
-        curl -sL "$API_URL" | grep -o '"tag_name": *"[^"]*"' | sed 's/"tag_name": *"//;s/"//' | head -10
+        echo "$releases_json" | grep -o '"tag_name": *"[^"]*"' | sed 's/"tag_name": *"//;s/"//' | head -10
         exit 1
     fi
-
-    RELEASE_TAG=$(echo "$release_json" | grep -o '"tag_name": *"[^"]*"' | sed 's/"tag_name": *"//' | sed 's/"//')
-    if [ -z "$RELEASE_TAG" ]; then
-        echo "ERROR: Could not parse release tag from GitHub API response"
-        exit 1
-    fi
-    echo "Release: $RELEASE_TAG"
-
-    CACHE_DIR="$CACHE_BASE/$RELEASE_TAG"
+    echo "Latest: $RELEASE_TAG"
+else
+    RELEASE_TAG="$INPUT"
 fi
 
+CACHE_DIR="$CACHE_BASE/$RELEASE_TAG"
 EXTRACT_DIR="$CACHE_DIR/extracted"
 
-# --- Log output to file while keeping terminal output ---
+# --- Log output ---
 
 mkdir -p "$CACHE_DIR/logs"
 LOG_FILE="$CACHE_DIR/logs/flash-$(date +%Y%m%d-%H%M%S).log"
 exec > >(tee "$LOG_FILE") 2>&1
 
-# --- Helper: find the tarball in cache dir ---
+# --- Helpers ---
 
 find_tarball() {
-    # Check for reassembled tarball first, then any .tar.gz (excluding .tmp)
     if [ -f "$CACHE_DIR/package.tar.gz" ]; then
         echo "$CACHE_DIR/package.tar.gz"
     else
@@ -162,13 +137,11 @@ find_tarball() {
     fi
 }
 
-# --- Helper: find the flash script in extracted dir ---
-
 find_flash_script() {
     sudo find "$EXTRACT_DIR" -name "l4t_initrd_flash.sh" -path "*/tools/kernel_flash/*" 2>/dev/null | head -1 || true
 }
 
-# --- Check if already fully extracted (skip everything) ---
+# --- Check if already extracted ---
 
 FLASH_SCRIPT=""
 if [ -f "$CACHE_DIR/.extract-done" ] && [ -d "$EXTRACT_DIR" ]; then
@@ -178,70 +151,70 @@ fi
 if [ -n "$FLASH_SCRIPT" ]; then
     echo "Using cached flash package."
 else
-    # --- Step 1: Obtain tarball ---
+    # --- Download if not cached ---
 
-    if [ "$NEED_DOWNLOAD" = true ]; then
+    TARBALL=$(find_tarball)
+
+    if [ -n "$TARBALL" ]; then
+        echo "Using cached download: $(basename "$TARBALL")"
+    else
+        echo "Fetching release $RELEASE_TAG..."
+        release_json=$(curl -sL "$API_URL/tags/$RELEASE_TAG")
+
+        if echo "$release_json" | grep -q '"message"'; then
+            msg=$(echo "$release_json" | grep -o '"message": *"[^"]*"' | head -1)
+            echo "ERROR: Release '$RELEASE_TAG' not found ($msg)"
+            echo ""
+            echo "Available releases:"
+            curl -sL "$API_URL" | grep -o '"tag_name": *"[^"]*"' | sed 's/"tag_name": *"//;s/"//' | head -10
+            exit 1
+        fi
+
+        assets=$(echo "$release_json" | grep -o '"browser_download_url": *"[^"]*"' | sed 's/"browser_download_url": *"//;s/"//' | grep -v '/archive/')
+
+        if [ -z "$assets" ]; then
+            echo "ERROR: No downloadable assets found in release $RELEASE_TAG"
+            exit 1
+        fi
+
+        mkdir -p "$CACHE_DIR"
+        rm -f "$CACHE_DIR"/*.tmp
+
+        echo ""
+        echo "Downloading to $CACHE_DIR ..."
+
+        while IFS= read -r url; do
+            filename=$(basename "$url")
+            [ "$filename" = "flash_from_package.sh" ] && continue
+
+            if [ -f "$CACHE_DIR/$filename" ]; then
+                echo "  Already downloaded: $filename"
+                continue
+            fi
+
+            echo "  Downloading $filename..."
+            curl -L --progress-bar -o "$CACHE_DIR/$filename.tmp" "$url"
+            mv "$CACHE_DIR/$filename.tmp" "$CACHE_DIR/$filename"
+        done <<< "$assets"
+        echo ""
+
+        # Reassemble split parts if needed
+        if ls "$CACHE_DIR"/*.part.* &>/dev/null; then
+            echo "Reassembling split parts..."
+            cat "$CACHE_DIR"/*.part.* > "$CACHE_DIR/package.tar.gz.tmp"
+            mv "$CACHE_DIR/package.tar.gz.tmp" "$CACHE_DIR/package.tar.gz"
+            rm -f "$CACHE_DIR"/*.part.*
+        fi
+
         TARBALL=$(find_tarball)
-
-        if [ -n "$TARBALL" ]; then
-            echo "Using cached tarball: $(basename "$TARBALL")"
-        else
-            # Parse download URLs from release JSON
-            assets=$(echo "$release_json" | grep -o '"browser_download_url": *"[^"]*"' | sed 's/"browser_download_url": *"//;s/"//' | grep -v '/archive/')
-
-            if [ -z "$assets" ]; then
-                echo "ERROR: No downloadable assets found in release $RELEASE_TAG"
-                exit 1
-            fi
-
-            mkdir -p "$CACHE_DIR"
-
-            # Clean up partial downloads from any previous failed run
-            rm -f "$CACHE_DIR"/*.tmp
-
-            echo ""
-            echo "Downloading to $CACHE_DIR ..."
-
-            while IFS= read -r url; do
-                filename=$(basename "$url")
-
-                # Skip the script itself if attached to the release
-                if [ "$filename" = "flash_from_package.sh" ]; then
-                    continue
-                fi
-
-                if [ -f "$CACHE_DIR/$filename" ]; then
-                    echo "  Already downloaded: $filename"
-                    continue
-                fi
-
-                echo "  Downloading $filename..."
-                curl -L --progress-bar -o "$CACHE_DIR/$filename.tmp" "$url"
-                mv "$CACHE_DIR/$filename.tmp" "$CACHE_DIR/$filename"
-            done <<< "$assets"
-            echo ""
-
-            # --- Step 2: Reassemble split parts if needed ---
-
-            if ls "$CACHE_DIR"/*.part.* &>/dev/null; then
-                echo "Reassembling split parts..."
-                cat "$CACHE_DIR"/*.part.* > "$CACHE_DIR/package.tar.gz.tmp"
-                mv "$CACHE_DIR/package.tar.gz.tmp" "$CACHE_DIR/package.tar.gz"
-                echo "Removing split parts..."
-                rm -f "$CACHE_DIR"/*.part.*
-            fi
-
-            TARBALL=$(find_tarball)
-            if [ -z "$TARBALL" ]; then
-                echo "ERROR: No .tar.gz found in $CACHE_DIR after download"
-                exit 1
-            fi
+        if [ -z "$TARBALL" ]; then
+            echo "ERROR: No .tar.gz found in $CACHE_DIR after download"
+            exit 1
         fi
     fi
 
-    # --- Step 3: Extract ---
+    # --- Extract ---
 
-    # Clean up any incomplete extraction from a previous failed run
     if [ -d "$EXTRACT_DIR" ] && [ ! -f "$CACHE_DIR/.extract-done" ]; then
         echo "Cleaning up incomplete extraction..."
         sudo rm -rf "$EXTRACT_DIR"
@@ -256,16 +229,13 @@ else
     if [ -z "$FLASH_SCRIPT" ]; then
         rm -f "$CACHE_DIR/.extract-done"
         echo "ERROR: l4t_initrd_flash.sh not found in extracted package."
-        echo "This doesn't appear to be a valid massflash package."
         exit 1
     fi
 fi
 
 FLASH_DIR=$(dirname "$FLASH_SCRIPT")
 
-# --- Display package build info if present ---
-# generate_flash_package.sh embeds BUILD_INFO.txt at the top of the tarball;
-# printing it here records the source commit in the per-run flash log.
+# --- Display package build info ---
 
 BUILD_INFO=$(sudo find "$EXTRACT_DIR" -maxdepth 3 -name "BUILD_INFO.txt" 2>/dev/null | head -1 || true)
 if [ -n "$BUILD_INFO" ]; then
@@ -286,7 +256,6 @@ echo "========================================="
 echo ""
 echo "Waiting for Jetson in recovery mode..."
 echo "  Connect USB and hold Force Recovery button while powering on."
-echo "  Looking for NVIDIA recovery device..."
 echo ""
 
 while true; do
@@ -299,8 +268,6 @@ while true; do
 done
 
 echo "Jetson detected!"
-echo ""
-echo "Starting flash..."
 echo ""
 
 cd "$FLASH_DIR"

--- a/packaging/publish_release.sh
+++ b/packaging/publish_release.sh
@@ -39,6 +39,11 @@ TARGET=$(cat "$LAST_TARGET_FILE")
 PRODUCT=$(echo "$TARGET" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 TAG="${PRODUCT}-${VERSION}"
 
+if ! git -C "$ROOT_DIR" diff-index --quiet HEAD --; then
+    echo "ERROR: Working tree has uncommitted changes. Commit or stash before releasing."
+    exit 1
+fi
+
 if git -C "$ROOT_DIR" rev-parse "$TAG" >/dev/null 2>&1; then
     echo "ERROR: Tag '$TAG' already exists."
     exit 1

--- a/packaging/publish_release.sh
+++ b/packaging/publish_release.sh
@@ -1,100 +1,62 @@
 #!/bin/bash
 
-# Publishes generated flash package(s) to GitHub Releases.
-# Tags the commit, creates a release, and uploads the files.
+# Creates a per-product release tag and pushes it. CI handles the build and
+# release creation.
 #
 # Usage: ./publish_release.sh <version>
-#   e.g. ./publish_release.sh v1.0.0
+#   e.g. ./publish_release.sh 6.2.1.1
+#
+# Reads LAST_BUILT_TARGET to determine the product prefix.
+# The resulting tag is e.g. pab-6.2.1.1
 
 set -e
 
 if [ $# -lt 1 ]; then
     echo "Usage: ./publish_release.sh <version>"
-    echo "  e.g. ./publish_release.sh v1.0.0"
+    echo "  e.g. ./publish_release.sh 6.2.1.1"
+    echo ""
+    echo "Reads LAST_BUILT_TARGET to determine the product prefix."
+    echo "Creates and pushes a tag — CI handles the rest."
     exit 1
 fi
 
 VERSION="$1"
-
-# Check gh is available
-if ! command -v gh &>/dev/null; then
-    echo "ERROR: gh (GitHub CLI) not installed. Install with: sudo apt install gh"
-    exit 1
-fi
-
-# Find tarballs and/or split part files (not reassemble.sh — the flash script handles that)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-RELEASE_FILES=()
 
-for f in "$ROOT_DIR"/ark-*.tar.gz; do
-    [ -f "$f" ] || continue
-    RELEASE_FILES+=("$f")
-done
-
-for d in "$ROOT_DIR"/ark-*_split; do
-    [ -d "$d" ] || continue
-    for part in "$d"/*.part.*; do
-        [ -f "$part" ] || continue
-        RELEASE_FILES+=("$part")
-    done
-done
-
-if [ ${#RELEASE_FILES[@]} -eq 0 ]; then
-    echo "ERROR: No ark-*.tar.gz or ark-*_split/ found in project root."
-    echo "Run packaging/generate_flash_package.sh first."
+if ! echo "$VERSION" | grep -qE '^[0-9]+(\.[0-9]+)*$'; then
+    echo "ERROR: Version must be digits and dots (e.g. 6.2.1.1), got: $VERSION"
     exit 1
 fi
 
-# Always include flash_from_package.sh
-if [ -f "$SCRIPT_DIR/flash_from_package.sh" ]; then
-    RELEASE_FILES+=("$SCRIPT_DIR/flash_from_package.sh")
-else
-    echo "WARNING: flash_from_package.sh not found, release will not include flash script."
+LAST_TARGET_FILE="$ROOT_DIR/source_build/LAST_BUILT_TARGET"
+if [ ! -f "$LAST_TARGET_FILE" ]; then
+    echo "ERROR: No LAST_BUILT_TARGET found. Run build_kernel.sh first."
+    exit 1
 fi
 
-echo "Files to upload:"
-for f in "${RELEASE_FILES[@]}"; do
-    echo "  $(basename "$f") ($(du -h "$f" | cut -f1))"
-done
+TARGET=$(cat "$LAST_TARGET_FILE")
+PRODUCT=$(echo "$TARGET" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+TAG="${PRODUCT}-${VERSION}"
+
+if git -C "$ROOT_DIR" rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "ERROR: Tag '$TAG' already exists."
+    exit 1
+fi
+
+echo "Target:  $TARGET"
+echo "Product: $PRODUCT"
+echo "Tag:     $TAG"
 echo ""
+read -p "Create and push tag '$TAG'? [y/N] " confirm
+if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+    echo "Aborted."
+    exit 0
+fi
 
-# Tag and push
-git tag -a "$VERSION" -m "$VERSION"
-git push origin "$VERSION"
-echo "Tagged and pushed: $VERSION"
-
-# Build release notes
-NOTES="## ARK Carrier Board Image $VERSION
-
-### Flashing
-
-Download and run the flash script:
-\`\`\`
-curl -LO https://github.com/ARK-Electronics/ark_jetson_kernel/releases/download/${VERSION}/flash_from_package.sh
-chmod +x flash_from_package.sh
-./flash_from_package.sh ${VERSION}
-\`\`\`
-
-The script downloads the package, reassembles it if split, and flashes the Jetson.
-
-**Requirements:** Ubuntu 22.04 host with USB connection. Put the Jetson in recovery mode (hold Force Recovery button while powering on) before or during the script — it will wait for detection.
-
-Supports all Orin Nano/NX module variants — the correct DTB is selected automatically at flash time."
-
-# Create release, then upload files one at a time
-echo ""
-echo "Creating GitHub release..."
-gh release create "$VERSION" \
-    --title "$VERSION" \
-    --notes "$NOTES"
-
-for f in "${RELEASE_FILES[@]}"; do
-    echo "Uploading $(basename "$f") ($(du -h "$f" | cut -f1))..."
-    gh release upload "$VERSION" "$f"
-    echo "  Done."
-done
+git -C "$ROOT_DIR" tag -a "$TAG" -m "$TAG"
+git -C "$ROOT_DIR" push origin "$TAG"
 
 echo ""
-echo "All uploads complete!"
-echo "Release: $(gh release view "$VERSION" --json url -q .url)"
+echo "Tag '$TAG' pushed. CI will build and create the release."
+echo "Monitor: https://github.com/ARK-Electronics/ark_jetson_kernel/actions"


### PR DESCRIPTION
## Summary

Replaces the single-version release model with per-product releases driven by git tags, so each carrier board gets its own independently versioned flash package.

## Problem

Releases used generic version tags (36.4.3, 36.4.3.1) with no per-product distinction. The build pipeline only builds one target at a time, but nothing enforced which target's image was in the release — PAB_V3 images ended up getting flashed on PAB hardware.

## Solution

Tag format: `{product}-{jetpack_version}.{ark_revision}` (e.g. `pab-6.2.1.1`, `jaj-6.2.1.1`, `pab-v3-6.2.1.1`). One release = one product = one image.

- **release.yml**: new CI workflow triggers on product tags, builds that specific carrier's kernel and flash package, and publishes a GitHub Release with the artifacts
- **flash_from_package.sh**: accepts a release tag (`pab-6.2.1.1`) or product name (`pab` for latest), downloads to cache, extracts, and flashes
- **publish_release.sh**: simplified to a tag-and-push convenience wrapper — CI handles the build and release creation
- **bsp_version.env**: adds `JETPACK_VERSION` field since the L4T-to-Jetpack mapping isn't derivable