### PR TITLE
fix(flash): drop Ubuntu 22.04 version gate from flash script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           ./flash_from_package.sh ${TAG}
           \`\`\`
 
-          Put the Jetson in recovery mode before running. Requires Ubuntu 22.04 host with USB connection. Supports all Orin Nano/NX module variants.
+          Put the Jetson in recovery mode before running. Requires a Debian/Ubuntu host with USB connection. Supports all Orin Nano/NX module variants.
           EOF
 
           gh release create "$TAG" \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Replace `<tag>` with a release tag for your product (e.g. `pab-6.2.1.1`, `jaj-6.
 ./flash_from_package.sh pab-v3    # latest PAB_V3 release
 ```
 
-Requires Ubuntu 22.04 host with USB connection. Put the Jetson in recovery mode before running. See [Releases](https://github.com/ARK-Electronics/ark_jetson_kernel/releases) for available versions.
+Requires a Debian/Ubuntu host with USB connection. Put the Jetson in recovery mode before running. See [Releases](https://github.com/ARK-Electronics/ark_jetson_kernel/releases) for available versions.
 
 ## Building from Source
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -92,6 +92,6 @@ Or flash the latest release for a product:
 ./flash_from_package.sh pab
 ```
 
-The script downloads the package, extracts it, waits for a Jetson in recovery mode, and flashes. No build tools or kernel source needed — just an Ubuntu 22.04 host with USB.
+The script downloads the package, extracts it, waits for a Jetson in recovery mode, and flashes. No build tools or kernel source needed — just a Debian/Ubuntu host with USB.
 
 Each version is cached in `~/.ark-jetson-cache/<tag>/` so re-running after a failure or switching between versions doesn't re-download.

--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -51,17 +51,11 @@ if [ "$1" = "--clean" ]; then
     exit 0
 fi
 
-# --- Check Ubuntu version ---
+# --- Check prerequisites available ---
 
-if [ -f /etc/lsb-release ]; then
-    DISTRO_VER=$(grep "DISTRIB_RELEASE" /etc/lsb-release | cut -d= -f2)
-    DISTRO_VER_NUM=$(echo "$DISTRO_VER" | sed 's/\.//')
-    if [ "$DISTRO_VER_NUM" -lt 2204 ] 2>/dev/null; then
-        echo "ERROR: Ubuntu 22.04 or newer is required (found $DISTRO_VER)."
-        exit 1
-    fi
-else
-    echo "WARNING: Could not detect Ubuntu version. Ubuntu 22.04+ is required."
+if ! command -v apt-get &>/dev/null; then
+    echo "ERROR: apt-get not found. This script requires a Debian/Ubuntu host."
+    exit 1
 fi
 
 # --- Install prerequisites ---


### PR DESCRIPTION
## Summary

Remove the hard Ubuntu 22.04 version check from `flash_from_package.sh` and update all docs/release notes to say "Debian/Ubuntu host" instead of "Ubuntu 22.04 host".

## Problem

The flash script and release notes claim Ubuntu 22.04 is required for flashing, but the 22.04 constraint only applies to **building** (kmod binary format incompatibility between host and device). Flashing pushes pre-built images over USB and works fine on 24.04 and other Debian-based hosts.

## Solution

- Replace the version gate in `flash_from_package.sh` with a simple `apt-get` existence check
- Update release notes template in `release.yml`, `README.md`, and `packaging/README.md`
- Already updated the live `pab-v3-6.2.1.1` release notes on GitHub