### PR TITLE
feat(build): record build metadata in rootfs at /etc/ark_jetson_kernel

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,6 +81,10 @@ if [ "$TARGET" != "all" ]; then
     done
 fi
 
+# Capture host OS before any container handoff — inside the build container,
+# /etc/os-release describes the container (always 22.04), not the actual host.
+[ -z "$ARK_BUILD_OS" ] && export ARK_BUILD_OS=$(. /etc/os-release && echo "$PRETTY_NAME")
+
 # Cache sudo credentials once upfront so sub-processes and docker don't
 # each prompt independently.
 sudo -v
@@ -386,6 +390,19 @@ done
 echo "Installing arducam_csi2.ko..."
 sudo cp "$SOURCE_DIR/nvidia-oot/drivers/media/i2c/arducam_csi2.ko" \
     "$L4T_DIR/rootfs/usr/lib/modules/$JETSON_KERNEL_VERSION/updates/drivers/media/i2c/"
+
+# ── Record build metadata ───────────────────────────────────────────────────
+
+BUILD_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse HEAD)
+BUILD_DATE=$(date -Iseconds)
+
+echo "Recording build metadata to rootfs/etc/ark_jetson_kernel..."
+sudo tee "$L4T_DIR/rootfs/etc/ark_jetson_kernel" >/dev/null <<EOF
+commit=$BUILD_COMMIT
+date=$BUILD_DATE
+build_os=$ARK_BUILD_OS
+target=$TARGET
+EOF
 
 # ── Done ────────────────────────────────────────────────────────────────────
 

--- a/scripts/container_runner.sh
+++ b/scripts/container_runner.sh
@@ -104,6 +104,7 @@ run_in_container() {
         -v "$HOME/l4t-gcc:/root/l4t-gcc" \
         -w /workspace \
         -e IN_BUILD_CONTAINER=1 \
+        -e ARK_BUILD_OS="$ARK_BUILD_OS" \
         "$ARK_BUILDER_IMAGE" \
         bash "/workspace/$(basename "$script_path")" "$@"
 }


### PR DESCRIPTION
## Summary

Write `/etc/ark_jetson_kernel` into the staged rootfs at the end of `build.sh` so a flashed Jetson carries the commit, build date, host OS, and target it was produced from.

## Problem

When customers report problems with their self-built images, there's no way to determine which commit of this repo they built from. The git hash is logged to `flash.log.txt` on the build host and embedded in massflash packages as `BUILD_INFO.txt`, but neither lands inside the rootfs that actually gets flashed onto the device.

## Solution

`ARK_BUILD_OS` is read from `/etc/os-release` before the container handoff — inside the 22.04 builder container it would always report 22.04 regardless of the real host — and propagated through docker via `container_runner.sh`. `build.sh` then writes `/etc/ark_jetson_kernel` (commit / date / build_os / target) at the end of every build invocation, so re-builds after `git pull` refresh the file. Fail-loud on `git rev-parse` failure rather than silently recording `commit=unknown`.