### PR TITLE
fix(build): capture build commit on host to avoid in-container git ownership error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -85,6 +85,11 @@ fi
 # /etc/os-release describes the container (always 22.04), not the actual host.
 [ -z "$ARK_BUILD_OS" ] && export ARK_BUILD_OS=$(. /etc/os-release && echo "$PRETTY_NAME")
 
+# Capture the build commit on the host. Inside the container the repo is
+# bind-mounted but owned by the host UID, so git refuses with "dubious
+# ownership" — resolve the hash here where git has the right ownership view.
+[ -z "$ARK_BUILD_COMMIT" ] && export ARK_BUILD_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse HEAD)
+
 # Cache sudo credentials once upfront so sub-processes and docker don't
 # each prompt independently.
 sudo -v
@@ -393,7 +398,7 @@ sudo cp "$SOURCE_DIR/nvidia-oot/drivers/media/i2c/arducam_csi2.ko" \
 
 # ── Record build metadata ───────────────────────────────────────────────────
 
-BUILD_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse HEAD)
+BUILD_COMMIT=$ARK_BUILD_COMMIT
 BUILD_DATE=$(date -Iseconds)
 
 echo "Recording build metadata to rootfs/etc/ark_jetson_kernel..."

--- a/scripts/container_runner.sh
+++ b/scripts/container_runner.sh
@@ -105,6 +105,7 @@ run_in_container() {
         -w /workspace \
         -e IN_BUILD_CONTAINER=1 \
         -e ARK_BUILD_OS="$ARK_BUILD_OS" \
+        -e ARK_BUILD_COMMIT="$ARK_BUILD_COMMIT" \
         "$ARK_BUILDER_IMAGE" \
         bash "/workspace/$(basename "$script_path")" "$@"
 }


### PR DESCRIPTION
## Summary

Resolve the build commit hash on the host and pass it into the container via `ARK_BUILD_COMMIT`, mirroring the existing `ARK_BUILD_OS` plumbing.

## Problem

`#74` added `BUILD_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse HEAD)` inside the metadata step, which runs inside the build container. The container bind-mounts the host repo at `/workspace` and runs as root, but the working tree is owned by the host UID — git 2.35.2+ aborts with `fatal: detected dubious ownership in repository at '/workspace'`. With `set -e` on, the build halts right after the arducam module install and never writes the metadata file or prints the "Build complete" banner.

## Solution

Capture `ARK_BUILD_COMMIT` on the host next to the existing `ARK_BUILD_OS` capture, forward it through `docker run -e`, and consume it from the env var in the metadata step instead of re-running git inside the container. Keeps the privilege boundary clean (no root-on-host-tree git, no `safe.directory` exception in the image).