### PR TITLE
fix(flash): drop --erase-all to prevent commodity-SSD bricking

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -118,7 +118,7 @@ if [ "$USE_INITRD" = true ]; then
     sudo ./tools/kernel_flash/l4t_initrd_flash.sh --external-device "$STORAGE_DEV" \
         -p "-c ./bootloader/generic/cfg/flash_t234_qspi.xml" \
         -c ./tools/kernel_flash/flash_l4t_t234_nvme.xml \
-        --erase-all --showlogs --network usb0 \
+        --showlogs --network usb0 \
         "$FLASH_TARGET" "$STORAGE_DEV"
 else
     sudo ./flash.sh "$FLASH_TARGET" "$STORAGE_DEV"

--- a/packaging/generate_flash_package.sh
+++ b/packaging/generate_flash_package.sh
@@ -99,7 +99,7 @@ if [ "$STORAGE" = "nvme" ]; then
         --external-device "$STORAGE_DEV" \
         -p "-c ./bootloader/generic/cfg/flash_t234_qspi.xml" \
         -c ./tools/kernel_flash/flash_l4t_t234_nvme.xml \
-        --erase-all --network usb0 \
+        --network usb0 \
         "$FLASH_TARGET" "$STORAGE_DEV"
 else
     sudo -E ./tools/kernel_flash/l4t_initrd_flash.sh \


### PR DESCRIPTION
## Summary
Remove `--erase-all` from the NVMe flash invocation in both the dev flash path (`flash.sh`) and the customer massflash package generator (`packaging/generate_flash_package.sh`).

## Problem
`--erase-all` makes NVIDIA's initrd run a whole-device `blkdiscard` on the NVMe before `usb0` networking comes up (device-side, in `nv_enable_remote.sh`). Commodity SSD controllers service that discard synchronously as a die-wide NAND erase, drawing a current spike that sags the carrier's 3.3V M.2 rail and resets the board before flashing can start — a hard brick of the flash. On our Swissbit SSDs the discard is deferred and serviced lazily as background GC, so the flag never actually cleaned the drive before flashing either — a no-op on our hardware, a brick on others.

## Solution
Drop the flag. The flash already provides a clean slate without it: the layout rewrites the protective MBR, primary GPT, and backup GPT on every run, and each partition is discarded (with a `dd`-zero fallback) immediately before its image is written. This also brings us into alignment with NVIDIA's own reference workflow for internal QSPI + external NVMe, which omits `--erase-all`. The QSPI reflash path is independent (`mtd_debug erase`) and unaffected.