### PR TITLE
fix(ci): build on /mnt to avoid ENOSPC during flash packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,17 @@ jobs:
           docker-images: true
           swap-storage: false
 
+      - name: Stage build tree on /mnt
+        # staging/ (extracted rootfs + massflash images + the multi-GB mfi tarball)
+        # overran the ~49 GB free on / and crashed the runner with ENOSPC during
+        # packaging. The ephemeral /mnt has ~65 GB free and is otherwise unused, so
+        # build there. The final package + split stay in the workspace on /, where
+        # the release step globs for them.
+        run: |
+          sudo mkdir -p /mnt/staging
+          sudo chown "$(id -u):$(id -g)" /mnt/staging
+          ln -s /mnt/staging staging
+
       - name: Install prerequisites
         env:
           DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
## Summary

Relocate the build's `staging/` tree onto the runner's ephemeral `/mnt` disk so draft-release packaging stops running out of disk.

## Problem

Draft tag builds crash the runner with `No space left on device` during *Generate flash package* — hard enough that the runner can't write its own diagnostic log, so there's no step error, just a .NET `IOException` annotation. The whole build runs on `/`, which has only ~49 GB free after cleanup. The massflash working set (extracted rootfs + system image + the ~5.6 GB `mfi` tarball, then transiently doubled by the `gunzip`→`gzip` round-trip and the `split`) peaks right at that ceiling. Inputs were identical to the prior successful drafts (same ARK-OS deb, same BSP), so this is a marginal capacity failure rather than a regression — the job had been riding just under the limit for several drafts. Meanwhile `/mnt` (~65 GB free) sits completely unused.

## Solution

Symlink `staging/` to `/mnt/staging` before the build. `build.sh` and `generate_flash_package.sh` create and operate under `staging/` transparently, so the multi-GB working set now lands on `/mnt`. The final package and its split parts still land in the workspace on `/`, where the release step globs for them, leaving `/` to hold only those (~11 GB) plus the cached `downloads/` and `.ccache`. CI runs on a 22.04 host, so the build is not containerized and a plain host symlink suffices — no bind-mount handling needed.
