### PR TITLE
docs(readme): remove prebuilt flash workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,29 +21,9 @@ This repository contains instructions and scripts for flashing your Jetson **Ori
 
 Each product has its own device tree overlay and optional kernel config in `products/{TARGET}/`. Build artifacts are fully isolated in per-product staging directories — you can build all three and flash any of them without cross-contamination.
 
-## Prebuilt Images (Recommended)
-
-Flash a Jetson without building from source. Download and run the flash script for your carrier board:
-
-```
-curl -LO https://github.com/ARK-Electronics/ark_jetson_kernel/releases/download/<tag>/flash_from_package.sh
-chmod +x flash_from_package.sh
-./flash_from_package.sh <tag>
-```
-
-Replace `<tag>` with a release tag for your product (e.g. `pab-6.2.1.1`, `jaj-6.2.1.1`, `pab-v3-6.2.1.1`). Or pass just the product name to flash the latest release:
-
-```
-./flash_from_package.sh pab       # latest PAB release
-./flash_from_package.sh jaj       # latest JAJ release
-./flash_from_package.sh pab-v3    # latest PAB_V3 release
-```
-
-Requires a Debian/Ubuntu host with USB connection. Put the Jetson in recovery mode before running. See [Releases](https://github.com/ARK-Electronics/ark_jetson_kernel/releases) for available versions.
-
 ## Building from Source
 
-If you need to customize the kernel or device tree, clone this repository and follow the steps below.
+Clone this repository and follow the steps below to build and flash your Jetson.
 
 ### 1. Setup
 Download the BSP, root filesystem, and kernel source tarballs:


### PR DESCRIPTION
## Summary

Remove the "Prebuilt Images (Recommended)" section from the README so users aren't pointed at the release flash packages while we're still validating them.

## Problem

The prebuilt flash packages still have open issues, but the README presents downloading and running them as the recommended way to flash a Jetson. That steers users toward a workflow we haven't validated.

## Solution

Drop the prebuilt section and present building from source as the documented flash path. The prebuilt workflow will be reintroduced in a follow-up draft PR once we've validated it ourselves.
