### PR TITLE
docs(readme): restore prebuilt flash workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,29 @@ This repository contains instructions and scripts for flashing your Jetson **Ori
 
 Each product has its own device tree overlay and optional kernel config in `products/{TARGET}/`. Build artifacts are fully isolated in per-product staging directories — you can build all three and flash any of them without cross-contamination.
 
+## Prebuilt Images (Recommended)
+
+Flash a Jetson without building from source. Download and run the flash script for your carrier board:
+
+```
+curl -LO https://github.com/ARK-Electronics/ark_jetson_kernel/releases/download/<tag>/flash_from_package.sh
+chmod +x flash_from_package.sh
+./flash_from_package.sh <tag>
+```
+
+Replace `<tag>` with a release tag for your product (e.g. `pab-6.2.1.1`, `jaj-6.2.1.1`, `pab-v3-6.2.1.1`). Or pass just the product name to flash the latest release:
+
+```
+./flash_from_package.sh pab       # latest PAB release
+./flash_from_package.sh jaj       # latest JAJ release
+./flash_from_package.sh pab-v3    # latest PAB_V3 release
+```
+
+Requires a Debian/Ubuntu host with USB connection. Put the Jetson in recovery mode before running. See [Releases](https://github.com/ARK-Electronics/ark_jetson_kernel/releases) for available versions.
+
 ## Building from Source
 
-Clone this repository and follow the steps below to build and flash your Jetson.
+If you need to customize the kernel or device tree, clone this repository and follow the steps below.
 
 ### 1. Setup
 Download the BSP, root filesystem, and kernel source tarballs:


### PR DESCRIPTION
## Summary

Restore the "Prebuilt Images (Recommended)" section to the README, reverting #80.

## Problem

#80 removed the prebuilt flash workflow from the README because the release flash packages still had open issues, so users shouldn't be steered toward them. Once the packages are validated, the section needs to come back.

## Solution

Revert #80 to reinstate the prebuilt section and the original "Building from Source" framing. Kept as a draft until we've validated the flash packages ourselves — mark ready for review once that's confirmed.
