### PR TITLE
feat(provision): ship python3-spidev in the image rootfs

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -161,6 +161,14 @@ sudo chroot "$ROOTFS_DIR" mkdir -p /etc/systemd/system/multi-user.target.wants
 sudo chroot "$ROOTFS_DIR" ln -sf /etc/systemd/system/jtop.service \
     /etc/systemd/system/multi-user.target.wants/jtop.service
 
+# spidev is needed by the manufacturing IMU test (ark_scripts JAJ bundle), which
+# runs under the system python. The test fixture gives the Jetson no internet, so
+# the module must ship in the image; the apt package is a prebuilt binary (PyPI
+# only has the sdist), keeping compilers out of the rootfs.
+echo "Installing python3-spidev (manufacturing IMU test)..."
+sudo chroot "$ROOTFS_DIR" apt-get install -y python3-spidev
+sudo chroot "$ROOTFS_DIR" python3 -c "import spidev"  # sanity: importable system-wide
+
 sudo rm "$ROOTFS_DIR/tmp/$MAVSDK_DEB" "$ROOTFS_DIR/tmp/$ARK_OS_DEB"
 
 PROVISION_ELAPSED=$(( $(date +%s) - PROVISION_START ))


### PR DESCRIPTION
## Summary
Bake `python3-spidev` into the provisioned rootfs so the manufacturing IMU test can import `spidev` on the test fixture.

## Problem
The JAJ bundle test (ark_scripts) checks the carrier's onboard ICM42688P over SPI with a python script that imports `spidev`. On the fixture the Jetson's only link is USB to the test host — no internet — so nothing can be pip-installed at test time, and `jaj-6.2.2.1` images fail the IMU test with `ModuleNotFoundError`. `smbus2` works today only because it rides along as a jetson-stats dependency; `spidev` has no such ride, and ARK-OS pins its sensor libs inside its private venv, which the system-python test can't see — so the image rootfs is the right home.

## Solution
apt-install `python3-spidev` in the provisioning chroot next to the jetson-stats system install, with an import sanity check. The apt package (3.5-3build1 in jammy/arm64 universe) is a prebuilt binary — PyPI ships spidev as sdist only, so pip would drag a compiler into the image. Installed unconditionally for all targets, matching the rest of provisioning.

## Testing
On a live Just-a-Jetson, to validate the IMU test before an image ships with this:
1. Give the Jetson internet: plug its ethernet jack into the lab network, or run `scripts/share_wifi.sh` on the host (USB-link NAT; the Jetson then also needs a default route via the host's `192.168.55.x` address and a nameserver).
2. On the Jetson: `sudo apt-get update && sudo apt-get install -y python3-spidev`
3. Verify: `python3 -c "import spidev"`
4. From the ark_scripts checkout on the test host, re-run the bundle test without reflashing: `./flash_and_test_just_a_jetson_bundle.sh -j` and confirm `Jetson IMU test PASSED`.

To validate the provisioning change itself: `./build.sh JAJ --provision` (add `--clean` if `staging/JAJ/` already exists), flash, and check `python3 -c "import spidev"` on the flashed unit.