### PR TITLE
fix(jaj): enable IMU SPI3 pinmux in MB1 BCT by default

### DIFF
--- a/products/JAJ/device_tree/bootloader/generic/BCT/tegra234-mb1-bct-pinmux-p3767-dp-a03.dtsi
+++ b/products/JAJ/device_tree/bootloader/generic/BCT/tegra234-mb1-bct-pinmux-p3767-dp-a03.dtsi
@@ -671,7 +671,7 @@
  
 			 spi3_sck_py0 {
 				 nvidia,pins = "spi3_sck_py0";
-				 nvidia,function = "rsvd1";
+				 nvidia,function = "spi3";
 				 nvidia,pull = <TEGRA_PIN_PULL_NONE>;
 				 nvidia,tristate = <TEGRA_PIN_DISABLE>;
 				 nvidia,enable-input = <TEGRA_PIN_DISABLE>;
@@ -681,7 +681,7 @@
  
 			 spi3_miso_py1 {
 				 nvidia,pins = "spi3_miso_py1";
-				 nvidia,function = "rsvd1";
+				 nvidia,function = "spi3";
 				 nvidia,pull = <TEGRA_PIN_PULL_DOWN>;
 				 nvidia,tristate = <TEGRA_PIN_ENABLE>;
 				 nvidia,enable-input = <TEGRA_PIN_ENABLE>;
@@ -691,7 +691,7 @@
  
 			 spi3_mosi_py2 {
 				 nvidia,pins = "spi3_mosi_py2";
-				 nvidia,function = "rsvd1";
+				 nvidia,function = "spi3";
 				 nvidia,pull = <TEGRA_PIN_PULL_NONE>;
 				 nvidia,tristate = <TEGRA_PIN_DISABLE>;
 				 nvidia,enable-input = <TEGRA_PIN_DISABLE>;
@@ -701,7 +701,7 @@
  
 			 spi3_cs0_py3 {
 				 nvidia,pins = "spi3_cs0_py3";
-				 nvidia,function = "rsvd1";
+				 nvidia,function = "spi3";
 				 nvidia,pull = <TEGRA_PIN_PULL_NONE>;
 				 nvidia,tristate = <TEGRA_PIN_DISABLE>;
 				 nvidia,enable-input = <TEGRA_PIN_DISABLE>;

--- a/products/JAJ/device_tree/bootloader/tegra234-mb1-bct-gpio-p3767-dp-a03.dtsi
+++ b/products/JAJ/device_tree/bootloader/tegra234-mb1-bct-gpio-p3767-dp-a03.dtsi
@@ -40,7 +40,6 @@
 		 gpio_main_default: default {
 			 gpio-input = <
 				 TEGRA234_MAIN_GPIO(B, 0)
-				 TEGRA234_MAIN_GPIO(Y, 1)
 				 TEGRA234_MAIN_GPIO(Y, 4)
 				 TEGRA234_MAIN_GPIO(Z, 1)
 				 TEGRA234_MAIN_GPIO(Z, 3)
@@ -71,9 +70,6 @@
 				 TEGRA234_MAIN_GPIO(K, 5)
 				 >;
 			 gpio-output-high = <
-				 TEGRA234_MAIN_GPIO(Y, 0)
-				 TEGRA234_MAIN_GPIO(Y, 2)
-				 TEGRA234_MAIN_GPIO(Y, 3)
 				 TEGRA234_MAIN_GPIO(Q, 3)
 				 TEGRA234_MAIN_GPIO(Q, 6)
 				 TEGRA234_MAIN_GPIO(A, 0)


### PR DESCRIPTION
## Summary
Root cause and fix for ARK-Electronics/ARK-OS#44 (JAJ IMU test fails on JetPack 6): the ICM42688P is on Tegra SPI3 (`/dev/spidev1.0`, CS0, pads PY0–PY3), but the shipped MB1 BCT claims those pads as GPIOs, which routes them to the GPIO controller (padctl bit[10] "sfsel" = 0) so the SPI controller's signals never reach the pins.

## Problem
Two layers stack: the BCT pinmux table leaves PY0–PY4 at `rsvd1`, and the BCT GPIO table claims SCK/MOSI/CS0 as GPIO outputs and MISO/CS1 as GPIO inputs (sfsel=0). On JetPack 6 the kernel pinctrl driver deliberately never sets sfsel when muxing an SFIO function — per NVIDIA, the BCT owns that bit ([forum thread](https://forums.developer.nvidia.com/t/40hdr-spi1-gpio-padctl-register-bit-10-effect-by-gpiod-tools-in-jp6/301171)) — so the jetson-io workaround from the issue muxes the function but the pad stays disconnected and MISO reads its pull-down forever (`WHO_AM_I=0x00`). Verified on a JAJ Orin NX on r36.5.0: with function and sfsel both set via direct padctl writes, the IMU answers `WHO_AM_I=0x47` on `spidev1.0` and the full production test passes. The earlier `pr-jaj-fix-spi-pinmux` attempt changed only the pinmux table, left the GPIO claims in place, and BCT edits additionally need a full flash to take effect — which is why it appeared not to work.

## Solution
Move PY0–PY3 out of the MB1 GPIO table and mux them as `spi3` in the MB1 pinmux table, so MB1 programs both the function and sfsel from power-on with no kernel or jetson-io involvement. CS1 (PY4) stays a GPIO input since the IMU is hardwired to CS0. The existing pad config (pulls, tristate, input-enable) already matched NVIDIA's spreadsheet template for spi3, so only the function values and GPIO claims change. Applies on the next full flash; validate by flashing a JAJ and running the bundle IMU test, which should pass from first boot with no jetson-io step.