### PR TITLE
fix(overlay): use "22pin CSI Connector" so jetson-io lists p3768 cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ For example:
    3. FE-PI Audio V1 and Z V2
    4. ReSpeaker 4 Mic Array
    5. ReSpeaker 4 Mic Linear Array
- Header 2: Jetson 24pin CSI Connector
+ Header 2: Jetson 22pin CSI Connector
    Available hardware modules:
    1. Camera ARK IMX219 Quad
    2. Camera ARK IMX477 Single

--- a/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-0000+p3768-0000-csi.dts
+++ b/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-0000+p3768-0000-csi.dts
@@ -11,7 +11,7 @@
 #include <dt-bindings/tegra234-p3767-0000-common.h>
 
 / {
-	overlay-name = "Jetson 24pin CSI Connector";
+	overlay-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	p3767-0000_p3768-0000-csi@0 {

--- a/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-quad.dts
+++ b/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-quad.dts
@@ -15,7 +15,7 @@
 
 / {
 	overlay-name = "Camera ARK IMX219 Quad";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment-camera@0 {

--- a/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-single.dts
+++ b/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-single.dts
@@ -11,7 +11,7 @@
 
 / {
 	overlay-name = "Camera ARK IMX219 Single";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment-camera@0 {

--- a/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx477-single.dts
+++ b/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx477-single.dts
@@ -11,7 +11,7 @@
 
 / {
 	overlay-name = "Camera ARK IMX477 Single";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment@0 {

--- a/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-A.dts
+++ b/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-A.dts
@@ -13,7 +13,7 @@
 
 / {
 	overlay-name = "Camera IMX219-A";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	/* IMX219 sensor module on CSI PORT A / cam1 */

--- a/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-C.dts
+++ b/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-C.dts
@@ -13,7 +13,7 @@
 
 / {
 	overlay-name = "Camera IMX219-C";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	/* IMX219 sensor module on CSI PORT B / cam0 */

--- a/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-dual.dts
+++ b/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-dual.dts
@@ -14,7 +14,7 @@
 
 / {
 	overlay-name = "Camera IMX219 Dual";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment-camera-imx219@0 {

--- a/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx477-dual.dts
+++ b/products/JAJ/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx477-dual.dts
@@ -12,7 +12,7 @@
 
 / {
 	overlay-name = "Camera IMX477 Dual";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment@0 {

--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-0000+p3768-0000-csi.dts
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-0000+p3768-0000-csi.dts
@@ -11,7 +11,7 @@
 #include <dt-bindings/tegra234-p3767-0000-common.h>
 
 / {
-	overlay-name = "Jetson 24pin CSI Connector";
+	overlay-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	p3767-0000_p3768-0000-csi@0 {

--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-quad.dts
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-quad.dts
@@ -15,7 +15,7 @@
 
 / {
 	overlay-name = "Camera ARK IMX219 Quad";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment-camera@0 {

--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-single.dts
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-single.dts
@@ -11,7 +11,7 @@
 
 / {
 	overlay-name = "Camera ARK IMX219 Single";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment-camera@0 {

--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx477-single.dts
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx477-single.dts
@@ -11,7 +11,7 @@
 
 / {
 	overlay-name = "Camera ARK IMX477 Single";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment@0 {

--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-A.dts
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-A.dts
@@ -13,7 +13,7 @@
 
 / {
 	overlay-name = "Camera IMX219-A";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	/* IMX219 sensor module on CSI PORT A / cam1 */

--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-C.dts
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-C.dts
@@ -13,7 +13,7 @@
 
 / {
 	overlay-name = "Camera IMX219-C";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	/* IMX219 sensor module on CSI PORT B / cam0 */

--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-dual.dts
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-dual.dts
@@ -14,7 +14,7 @@
 
 / {
 	overlay-name = "Camera IMX219 Dual";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment-camera-imx219@0 {

--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx477-dual.dts
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx477-dual.dts
@@ -12,7 +12,7 @@
 
 / {
 	overlay-name = "Camera IMX477 Dual";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment@0 {

--- a/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-0000+p3768-0000-csi.dts
+++ b/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-0000+p3768-0000-csi.dts
@@ -11,7 +11,7 @@
 #include <dt-bindings/tegra234-p3767-0000-common.h>
 
 / {
-	overlay-name = "Jetson 24pin CSI Connector";
+	overlay-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	p3767-0000_p3768-0000-csi@0 {

--- a/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-quad.dts
+++ b/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-quad.dts
@@ -15,7 +15,7 @@
 
 / {
 	overlay-name = "Camera ARK IMX219 Quad";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment-camera@0 {

--- a/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-single.dts
+++ b/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx219-single.dts
@@ -11,7 +11,7 @@
 
 / {
 	overlay-name = "Camera ARK IMX219 Single";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment-camera@0 {

--- a/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx477-single.dts
+++ b/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-ark-imx477-single.dts
@@ -11,7 +11,7 @@
 
 / {
 	overlay-name = "Camera ARK IMX477 Single";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment@0 {

--- a/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-A.dts
+++ b/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-A.dts
@@ -13,7 +13,7 @@
 
 / {
 	overlay-name = "Camera IMX219-A";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	/* IMX219 sensor module on CSI PORT A / cam1 */

--- a/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-C.dts
+++ b/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-C.dts
@@ -13,7 +13,7 @@
 
 / {
 	overlay-name = "Camera IMX219-C";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	/* IMX219 sensor module on CSI PORT B / cam0 */

--- a/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-dual.dts
+++ b/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx219-dual.dts
@@ -14,7 +14,7 @@
 
 / {
 	overlay-name = "Camera IMX219 Dual";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment-camera-imx219@0 {

--- a/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx477-dual.dts
+++ b/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/tegra234-p3767-camera-p3768-imx477-dual.dts
@@ -12,7 +12,7 @@
 
 / {
 	overlay-name = "Camera IMX477 Dual";
-	jetson-header-name = "Jetson 24pin CSI Connector";
+	jetson-header-name = "Jetson 22pin CSI Connector";
 	compatible = JETSON_COMPATIBLE_P3768;
 
 	fragment@0 {


### PR DESCRIPTION
## Summary
On p3768 (Orin Nano/NX) targets, the camera/CSI overlays never appeared in `jetson-io` (`config-by-hardware.py -l`) even though they were present in `/boot`. They declared a CSI header name the current BSP's jetson-io no longer recognizes, so the entire camera category was silently hidden.

## Problem
`config-by-hardware` only lists an overlay whose `jetson-header-name` (camera modules) or `overlay-name` (the connector definer) matches an entry in jetson-io's built-in `Headers.HDRS` registry. NVIDIA renamed the Orin Nano/NX CSI connector from "24pin" to "22pin" in L4T R36 — R36.5.0 jetson-io registers only `Jetson 22pin CSI Connector` and contains no "24pin" string anywhere. The vendored p3768 overlays still declared `Jetson 24pin CSI Connector` (the legacy JetPack-5 name), so nothing matched a known header and the whole CSI group disappeared; only the 40-pin header (audio + ARK I2S) showed. `build.sh` copies these vendored overlays over NVIDIA's correct R36.5.0 ones, so the stale name always won.

## Solution
Rename `Jetson 24pin CSI Connector` → `Jetson 22pin CSI Connector` in the p3768 camera overlays and the CSI connector definer across PAB/JAJ/PAB_V3, matching NVIDIA's pristine R36.5.0 dtbos, and update the README example output. Verified on a flashed PAB by patching the built dtbos with the new name and re-running jetson-io's matcher: `Jetson 22pin CSI Connector` now lists the ARK IMX219 Quad / IMX219 Single / IMX477 Single modules. This restores jetson-io visibility/selectability only; camera bring-up is unaffected (the quad-IMX219 already comes up from the base DTB).
