### PR TITLE
fix(build): rebuild builder image when the Dockerfile changes

### DIFF
--- a/scripts/container_runner.sh
+++ b/scripts/container_runner.sh
@@ -63,9 +63,25 @@ run_in_container() {
 
     ensure_docker
 
-    if ! "${DOCKER_CMD[@]}" image inspect "$ARK_BUILDER_IMAGE" >/dev/null 2>&1; then
-        echo "Building $ARK_BUILDER_IMAGE (one-time, ~30-60s)..."
-        "${DOCKER_CMD[@]}" build -t "$ARK_BUILDER_IMAGE" "$repo_dir/docker/"
+    # Rebuild when the image is missing OR the Dockerfile changed since it was built.
+    # An existence-only check silently keeps a stale image after a Dockerfile edit (e.g.
+    # missing a newly-added tool, failing later with "command not found"). Stamp the build
+    # with a content-hash label and compare it back — the :22.04 tag stays stable and the
+    # check needs no network.
+    local want_sha have_sha
+    want_sha=$(sha256sum "$repo_dir/docker/Dockerfile" | cut -d' ' -f1)
+    have_sha=$("${DOCKER_CMD[@]}" image inspect \
+        --format '{{ if .Config.Labels }}{{ index .Config.Labels "dockerfile_sha" }}{{ end }}' \
+        "$ARK_BUILDER_IMAGE" 2>/dev/null) || have_sha=""
+
+    if [ "$want_sha" != "$have_sha" ]; then
+        if [ -n "$have_sha" ]; then
+            echo "Dockerfile changed — rebuilding $ARK_BUILDER_IMAGE..."
+        else
+            echo "Building $ARK_BUILDER_IMAGE (one-time, ~30-60s)..."
+        fi
+        "${DOCKER_CMD[@]}" build --label "dockerfile_sha=$want_sha" \
+            -t "$ARK_BUILDER_IMAGE" "$repo_dir/docker/"
     fi
 
     # Persistent ccache for container builds: the container is --rm, so without a host


### PR DESCRIPTION
## Summary
The 22.04 builder image is only rebuilt when it's missing, so a `docker/Dockerfile` change never reaches hosts that already have the image. Rebuild when the Dockerfile changes too.

## Problem
`run_in_container()` in `scripts/container_runner.sh` guarded the build on `docker image inspect` (existence only). After the Dockerfile gained `curl`/`wget` in #76, any host with a pre-#76 `ark-jetson-builder:22.04` kept using the stale image, and `--provision` builds died with `curl: command not found`. Nothing short of a manual `docker build`/`docker rmi` ever refreshed it.

## Solution
Stamp each build with a `dockerfile_sha` label (sha256 of `docker/Dockerfile`) and compare it back on every run; rebuild when the label is missing or differs. The `:22.04` tag stays stable, the check needs no network, and the image is rebuilt exactly when the Dockerfile changes. Existing unlabeled images rebuild once, then match thereafter.
