### PR TITLE
docs(readme): trim to core flow, break out advanced topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ARK Jetson Carrier Setup
 
-This repository contains instructions and scripts for flashing your Jetson **Orin Nano** or **Orin NX** on an ARK Jetson Carrier.
+Scripts for building and flashing a Jetson **Orin Nano** or **Orin NX** on an ARK Jetson Carrier.
 
 | Component | Version |
 | --- | --- |
@@ -13,243 +13,86 @@ This repository contains instructions and scripts for flashing your Jetson **Ori
 
 ## Products
 
-| Target | Carrier Board | Notes |
+| Target | Carrier Board |
 | --- | --- | --- |
-| `PAB` | ARK Jetson PAB Carrier | DP bidir pinmux |
-| `JAJ` | ARK Just a Jetson Carrier | HDMI pinmux |
-| `PAB_V3` | ARK Jetson PAB V3 Carrier | Separate product (not PAB Rev3), KSZ8795 ethernet switch |
+| `PAB` | ARK Jetson PAB Carrier |
+| `JAJ` | ARK Just a Jetson Carrier |
+| `PAB_V3` | ARK Jetson PAB V3 Carrier |
 
-Each product has its own device tree overlay and optional kernel config in `products/{TARGET}/`. Build artifacts are fully isolated in per-product staging directories — you can build all three and flash any of them without cross-contamination.
-
-## Building from Source
-
-Clone this repository and follow the steps below to build and flash your Jetson.
+## Build & Flash
 
 ### 1. Setup
-Download the BSP, root filesystem, and kernel source tarballs:
+Download the BSP, root filesystem, and kernel source tarballs (one time):
 ```
 ./setup.sh
 ```
 
 ### 2. Build
-Build a target. The first build stages the full L4T tree (extract, configure rootfs) which takes several minutes. Subsequent builds skip staging and just recompile.
 ```
-./build.sh PAB        # build one target
-./build.sh all        # build all three
-./build.sh PAB --clean  # wipe staging and rebuild from scratch
+./build.sh PAB --clean --provision
 ```
+- Targets are `PAB`, `JAJ`, `PAB_V3`, or `all`.
+- `--clean` wipes `staging/{TARGET}/` and re-stages from scratch.
+- `--provision` preinstalls [ARK-OS](https://github.com/ARK-Electronics/ARK-OS) and tooling into the image. Omit it for a bare image. To bake in your own packages, edit [`provision.sh`](provision.sh).
 
 ### 3. Add WiFi (optional)
-
-You can optionally add your WiFi network after building and before flashing:
+Bake a WiFi profile into the image before flashing:
 ```
-./scripts/add_wifi_network.sh YourNetworkName YourPassword
+./scripts/add_wifi_network.sh PAB YourNetworkName YourPassword
 ```
-
-If you didn't configure the WiFi network before flashing, you can ssh in over the micro USB and use network manager to add your network:
+Or add it later over the USB connection:
 ```
 ssh jetson@jetson.local
 sudo nmcli dev wifi connect YourNetworkName password YourPassword
 ```
 
 ### 4. Flash
-Connect a micro USB cable to the port adjacent to the mini HDMI. Power on with the Force Recovery button held. You can verify the Jetson is in recovery mode by checking `lsusb`.
-> Bus 001 Device 012: ID 0955:7523 NVIDIA Corp. APX
-
-Flash the image:
+Connect to the USB port, then power on with the Force Recovery button held.
 ```
 ./flash.sh PAB
 ```
-
-#### Flash options
-
-By default, `flash.sh` targets NVMe + Orin Super. For other configurations:
-
+By default `flash.sh` targets NVMe on an Orin Super module. Other layouts:
 ```
-# Flash to SD card (NVIDIA dev kit modules)
-./flash.sh PAB --sdcard
-
-# Flash to USB thumb drive
-./flash.sh PAB --usb
-
-# Flash non-super module variant
-./flash.sh PAB --no-super
-
-# Both
-./flash.sh PAB --sdcard --no-super
+./flash.sh PAB --sdcard     # SD card (NVIDIA dev kit modules)
+./flash.sh PAB --usb        # USB thumb drive
+./flash.sh PAB --no-super   # non-super module variant
 ```
 
-Once complete, SSH in via Micro USB or WiFi.
+When flashing completes, SSH in over Micro USB or WiFi:
 ```
 ssh jetson@jetson.local
 ```
 
-> **Tip:** To avoid typing the password on every connection, copy your SSH key to the Jetson once with `ssh-copy-id jetson@jetson.local`.
+> **Tip:** Run `ssh-copy-id jetson@jetson.local` once so you don't type the password on every connection.
 
-> **Tip:** Run `./scripts/add_ssh_config.sh` once to add a `jetson` entry to your `~/.ssh/config`. Then you can connect with just `ssh jetson`, and reflashing the Jetson won't trip the "REMOTE HOST IDENTIFICATION HAS CHANGED" warning.
+> **Tip:** Run `./scripts/add_ssh_config.sh` once to add a `jetson` host to your `~/.ssh/config`. Then `ssh jetson` works, and reflashing won't trip the "REMOTE HOST IDENTIFICATION HAS CHANGED" warning.
 
-### 5. Generate & Publish Flash Package (optional)
+## Cameras
 
-See [packaging/](packaging/) for how to generate distributable flash packages and publish them to GitHub Releases.
-
-### 6. Install ARK Software (optional)
-You can now optionally install the ARK software packages, which provide handy tools for working with the Jetson on an ARK carrier.
-
-https://github.com/ARK-Electronics/ARK-OS
-
----
-
-## Additional Documentation
-
-The sections below cover advanced topics for reference. Most users will not need these for initial setup.
-
-
-### Flashing the QSPI Bootloader
-You can flash just the QSPI bootloader and install a pre-flashed NVME afterwards ([NVIDIA Docs](https://docs.nvidia.com/jetson/archives/r36.3/DeveloperGuide/SD/FlashingSupport.html#examples)). If you are upgrading from Jetpack5 to Jetpack6 you must reflash the QSPI bootloader.
-```
-cd staging/PAB/Linux_for_Tegra/
-sudo ./flash.sh --no-systemimg -c bootloader/generic/cfg/flash_t234_qspi.xml jetson-orin-nano-devkit-super nvme0n1p1
-```
-If the ./flash.sh command fails, try the l4t_initrd_flash.sh command:
-```
-sudo ./tools/kernel_flash/l4t_initrd_flash.sh -p "--no-systemimg -c bootloader/generic/cfg/flash_t234_qspi.xml" --network usb0 jetson-orin-nano-devkit-super nvme0n1p1
-```
-
----
-
-### Changing Jetson Clock Speeds
-To show the current settings:
-```
-sudo jetson_clocks --show
-```
-To store the current settings:
-```
-sudo jetson_clocks --store
-```
-To maximize Jetson Orin performance:
-```
-sudo jetson_clocks
-```
-To restore the previous settings:
-```
-sudo jetson_clocks --restore
-```
-
----
-
-### Jetson Super Mode
-After flashing or updating to JetPack 6.2, run the following command to start the newly available Super Mode.
-
-MAXN SUPER mode on Jetson Orin Nano Modules:
-```
-sudo nvpmodel -m 2
-```
-MAXN SUPER mode on Jetson Orin NX Modules:
-```
-sudo nvpmodel -m 0
-```
-
----
-
-### Camera Support
-See [docs/cameras.md](docs/cameras.md) for tested cameras, overlays, and test commands (GStreamer, v4l2-ctl).
-
-### 10GbE Ethernet (Auvidea M20E)
-See [docs/10gbe_ethernet.md](docs/10gbe_ethernet.md) for using the Auvidea M20E M.2 10GbE adapter with a USB boot drive.
-
-### I2C Buses
-See [docs/i2c.md](docs/i2c.md) for the I2C bus map (connector signal → `/dev/i2c-N`), on-bus devices, and scanning with `i2cdetect`.
-
-### GPIO
-See [docs/gpio.md](docs/gpio.md) for driving the 40-pin / I2S header pins as GPIO, boot-time pad defaults (MB1 BCT), and safe-state patterns.
-
----
-
-### Manual Kernel Build (Advanced)
-The following steps are automated by `build.sh`. For manual builds, adjust the target directory as needed:
-
-#### Building the kernel, modules, and dtbs
-```
-export CROSS_COMPILE=$HOME/l4t-gcc/aarch64--glibc--stable-2022.08-1/bin/aarch64-buildroot-linux-gnu-
-export KERNEL_HEADERS=$PWD/staging/PAB/Linux_for_Tegra/source/kernel/kernel-jammy-src
-export INSTALL_MOD_PATH=$PWD/staging/PAB/Linux_for_Tegra/rootfs/
-cd staging/PAB/Linux_for_Tegra/source
-make -C kernel && make modules && make dtbs
-```
-Install the kernel into the staging directory:
-```
-sudo -E make install -C kernel
-```
-Copy the kernel image:
-```
-cp kernel/kernel-jammy-src/arch/arm64/boot/Image ../../kernel/
-```
-
----
-
-### Building the Camera Overlay DTBs
-The camera overlays can be built and installed onto the Jetson without needing to reflash.
-```
-export CROSS_COMPILE=$HOME/l4t-gcc/aarch64--glibc--stable-2022.08-1/bin/aarch64-buildroot-linux-gnu-
-export KERNEL_HEADERS=$PWD/staging/PAB/Linux_for_Tegra/source/kernel/kernel-jammy-src
-cd staging/PAB/Linux_for_Tegra/source/
-make dtbs
-```
-
-Copy the overlay DTB to the Jetson via Micro-USB:
-```
-DTB_PATH="staging/PAB/Linux_for_Tegra/source/kernel-devicetree/generic-dts/dtbs/"
-OVERLAY_DTB=<your_overlay>
-scp $DTB_PATH/$OVERLAY_DTB jetson@192.168.55.1:~
-```
-Installing the overlay requires sudo so you will then need to SSH into the Jetson and move the overlay into **/boot**.
-```
-ssh jetson@192.168.55.1
-sudo mv <your_overlay> /boot
-```
-You can then select your overlay using the Jetson-IO tool. List the available overlays to ensure yours is available.
+Select a camera overlay with NVIDIA's `jetson-io` tool. List what's available:
 ```
 sudo /opt/nvidia/jetson-io/config-by-hardware.py -l
 ```
-For example:
 ```
  Header 1 [default]: Jetson 40pin Header
-   Available hardware modules:
-   1. Adafruit SPH0645LM4H
-   2. Adafruit UDA1334A
-   3. FE-PI Audio V1 and Z V2
-   4. ReSpeaker 4 Mic Array
-   5. ReSpeaker 4 Mic Linear Array
+   ...
  Header 2: Jetson 22pin CSI Connector
    Available hardware modules:
    1. Camera ARK IMX219 Quad
    2. Camera ARK IMX477 Single
 ```
-
-Apply your overlay, for example:
+Apply one and reboot:
 ```
 sudo /opt/nvidia/jetson-io/config-by-hardware.py -n 2="Camera ARK IMX477 Single"
-```
-
-Reboot and your new device tree will be active.
-```
 sudo reboot
 ```
-You can check that LibArgus can find your camera sensor:
-```
-nvargus_nvraw --lps
-```
+See [docs/cameras.md](docs/cameras.md) for supported sensors, overlay names, and how to verify and stream a camera.
 
----
-
-### Notes on Building the Kernel and Modifying the Device Tree
-To make changes to the kernel device tree you must build the kernel from source. After building from source, the device tree binaries are installed into the staging directory and included in the next flash.
-
-Note that there are different device tree binaries depending on the module and RAM. <br>
-https://docs.nvidia.com/jetson/archives/r36.3/DeveloperGuide/HR/JetsonModuleAdaptationAndBringUp/JetsonOrinNxNanoSeries.html#porting-the-linux-kernel-device-tree <br>
-**Orin NX 16GB-DRAM**   : tegra234-p3768-0000+p3767-**0000**-nv.dtb <br>
-**Orin NX 8GB-DRAM**    : tegra234-p3768-0000+p3767-**0001**-nv.dtb <br>
-**Orin Nano 8GB-DRAM**  : tegra234-p3768-0000+p3767-**0003**-nv.dtb <br>
-**Orin Nano 4GB-DRAM**  : tegra234-p3768-0000+p3767-**0004**-nv.dtb <br>
-
-The device tree source files for each product live in `products/{TARGET}/device_tree/`. These are overlaid onto the NVIDIA kernel source during build. To modify the device tree, edit the files in the product directory and re-run `./build.sh <TARGET>`.
+## More documentation
+- [docs/cameras.md](docs/cameras.md) — supported sensors, overlays, and streaming
+- [docs/gpio.md](docs/gpio.md) — 40-pin / I2S header GPIO and boot-time pad defaults
+- [docs/i2c.md](docs/i2c.md) — I2C bus map and scanning
+- [docs/10gbe_ethernet.md](docs/10gbe_ethernet.md) — Auvidea M20E 10GbE adapter
+- [docs/performance.md](docs/performance.md) — clock speeds and Super Mode
+- [docs/kernel_development.md](docs/kernel_development.md) — manual kernel builds and device tree changes
+- [docs/build_host.md](docs/build_host.md) — why the build pins to Ubuntu 22.04

--- a/docs/cameras.md
+++ b/docs/cameras.md
@@ -43,6 +43,8 @@ IMX477 4-lane overlays have been removed. While the Sony IMX477 sensor silicon s
 
 ## Installing a Camera Overlay
 
+A full flash already includes every overlay — `build.sh` copies them into the image's `/boot`, so after flashing you can skip straight to `jetson-io` below. The build-and-copy steps here are for **iterating on an overlay without reflashing**: rebuild the `.dtbo`, drop it on the running target, and re-select it.
+
 Build the overlay DTBs (from host):
 ```
 ./build.sh PAB   # or JAJ, PAB_V3

--- a/docs/kernel_development.md
+++ b/docs/kernel_development.md
@@ -1,10 +1,10 @@
 # Kernel & Device Tree Development
 
-`build.sh` automates everything below. These notes are for manual builds and for understanding how the device tree is assembled.
+`build.sh` automates everything below. These notes are for manual builds, for adding out-of-tree modules, and for understanding how the device tree is assembled.
 
 ## Manual kernel build
 
-The steps below build the kernel, modules, and DTBs by hand. Adjust the `PAB` path for your target.
+The steps below build and install the kernel, modules, and DTBs by hand. Adjust the `PAB` path for your target.
 
 Set up the cross-compile environment:
 ```
@@ -14,22 +14,23 @@ export INSTALL_MOD_PATH=$PWD/staging/PAB/Linux_for_Tegra/rootfs/
 cd staging/PAB/Linux_for_Tegra/source
 make -C kernel && make modules && make dtbs
 ```
-Install the kernel into the staging rootfs:
+Install the kernel with its in-tree modules and DTBs, then the out-of-tree modules (the NVIDIA display driver and other OOT drivers that `make modules` builds):
 ```
 sudo -E make install -C kernel
+sudo -E make modules_install
 ```
-Copy the kernel image into place:
+Copy the kernel image into `../kernel/`, where `flash.sh` reads it:
 ```
-cp kernel/kernel-jammy-src/arch/arm64/boot/Image ../../kernel/
+cp kernel/kernel-jammy-src/arch/arm64/boot/Image ../kernel/
 ```
+
+`build.sh` does two more things a from-scratch flash needs, which the steps above leave out: it copies the per-module DTBs and camera `.dtbo` overlays from `kernel-devicetree/generic-dts/dtbs/` into both `rootfs/boot/` and `kernel/dtb/`, and it repoints the `lib/modules/<release>/{build,source}` symlinks at the on-target headers package (so DKMS and on-target module builds resolve their headers). Replicate those by hand, or just run `./build.sh <TARGET>`.
 
 ## Modifying the device tree
 
-To change the device tree you must build the kernel from source. The resulting DTBs are installed into the staging directory and included in the next flash.
+To change the device tree you must build from source. The device tree sources for each product live in `products/{TARGET}/device_tree/`. `build.sh` overlays these onto the NVIDIA kernel source on every build, so edit the files there and re-run `./build.sh <TARGET>`.
 
-The device tree source for each product lives in `products/{TARGET}/device_tree/`. `build.sh` overlays these onto the NVIDIA kernel source on every build, so edit the files there and re-run `./build.sh <TARGET>`.
-
-The correct DTB depends on the module and its RAM ([NVIDIA porting guide](https://docs.nvidia.com/jetson/archives/r36.3/DeveloperGuide/HR/JetsonModuleAdaptationAndBringUp/JetsonOrinNxNanoSeries.html#porting-the-linux-kernel-device-tree)):
+The base DTB is selected by module and RAM ([NVIDIA porting guide](https://docs.nvidia.com/jetson/archives/r36.3/DeveloperGuide/HR/JetsonModuleAdaptationAndBringUp/JetsonOrinNxNanoSeries.html#porting-the-linux-kernel-device-tree)):
 
 | Module | DTB |
 | --- | --- |
@@ -37,3 +38,21 @@ The correct DTB depends on the module and its RAM ([NVIDIA porting guide](https:
 | Orin NX 8GB | `tegra234-p3768-0000+p3767-0001-nv.dtb` |
 | Orin Nano 8GB | `tegra234-p3768-0000+p3767-0003-nv.dtb` |
 | Orin Nano 4GB | `tegra234-p3768-0000+p3767-0004-nv.dtb` |
+
+Changing the base DTB requires a reflash. **Overlays do not** — a rebuilt `.dtbo` can be copied to the target's `/boot` and selected with `jetson-io`, no reflash needed. Overlay sources live next to the base tree under `products/{TARGET}/device_tree/source/hardware/nvidia/t23x/nv-public/overlay/` (the ARK camera overlays are the `*-ark-*.dts` files) and compile to `kernel-devicetree/generic-dts/dtbs/*.dtbo`. See [cameras.md](cameras.md#installing-a-camera-overlay) for the build → copy → `jetson-io` loop.
+
+## Out-of-tree kernel modules
+
+The OOT modules that ship with the BSP are installed by the `make modules` / `make modules_install` steps above. To build your *own* external module against the staged kernel, reuse the same `CROSS_COMPILE` and `KERNEL_HEADERS` exports from the manual build, then point kbuild at your module directory:
+```
+make -C "$KERNEL_HEADERS" M=$PWD ARCH=arm64 modules
+```
+To load the result on a running Jetson without reflashing, copy the `.ko` over, refresh the module index, and load it:
+```
+scp my_module.ko jetson@jetson.local:~
+ssh jetson@jetson.local
+sudo cp my_module.ko /lib/modules/$(uname -r)/extra/
+sudo depmod -a
+sudo modprobe my_module
+```
+The flashed image already carries the matching kernel headers — `build.sh` repoints `/lib/modules/<release>/build` at them — so modules can also be built on-target or rebuilt automatically via DKMS.

--- a/docs/kernel_development.md
+++ b/docs/kernel_development.md
@@ -1,0 +1,39 @@
+# Kernel & Device Tree Development
+
+`build.sh` automates everything below. These notes are for manual builds and for understanding how the device tree is assembled.
+
+## Manual kernel build
+
+The steps below build the kernel, modules, and DTBs by hand. Adjust the `PAB` path for your target.
+
+Set up the cross-compile environment:
+```
+export CROSS_COMPILE=$HOME/l4t-gcc/aarch64--glibc--stable-2022.08-1/bin/aarch64-buildroot-linux-gnu-
+export KERNEL_HEADERS=$PWD/staging/PAB/Linux_for_Tegra/source/kernel/kernel-jammy-src
+export INSTALL_MOD_PATH=$PWD/staging/PAB/Linux_for_Tegra/rootfs/
+cd staging/PAB/Linux_for_Tegra/source
+make -C kernel && make modules && make dtbs
+```
+Install the kernel into the staging rootfs:
+```
+sudo -E make install -C kernel
+```
+Copy the kernel image into place:
+```
+cp kernel/kernel-jammy-src/arch/arm64/boot/Image ../../kernel/
+```
+
+## Modifying the device tree
+
+To change the device tree you must build the kernel from source. The resulting DTBs are installed into the staging directory and included in the next flash.
+
+The device tree source for each product lives in `products/{TARGET}/device_tree/`. `build.sh` overlays these onto the NVIDIA kernel source on every build, so edit the files there and re-run `./build.sh <TARGET>`.
+
+The correct DTB depends on the module and its RAM ([NVIDIA porting guide](https://docs.nvidia.com/jetson/archives/r36.3/DeveloperGuide/HR/JetsonModuleAdaptationAndBringUp/JetsonOrinNxNanoSeries.html#porting-the-linux-kernel-device-tree)):
+
+| Module | DTB |
+| --- | --- |
+| Orin NX 16GB | `tegra234-p3768-0000+p3767-0000-nv.dtb` |
+| Orin NX 8GB | `tegra234-p3768-0000+p3767-0001-nv.dtb` |
+| Orin Nano 8GB | `tegra234-p3768-0000+p3767-0003-nv.dtb` |
+| Orin Nano 4GB | `tegra234-p3768-0000+p3767-0004-nv.dtb` |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,33 @@
+# Power & Performance
+
+## Clock speeds
+
+Show the current settings:
+```
+sudo jetson_clocks --show
+```
+Store the current settings:
+```
+sudo jetson_clocks --store
+```
+Maximize performance:
+```
+sudo jetson_clocks
+```
+Restore the previous settings:
+```
+sudo jetson_clocks --restore
+```
+
+## Super Mode
+
+After flashing or updating to JetPack 6.2, enable MAXN SUPER mode.
+
+Orin Nano modules:
+```
+sudo nvpmodel -m 2
+```
+Orin NX modules:
+```
+sudo nvpmodel -m 0
+```

--- a/docs/qspi_bootloader.md
+++ b/docs/qspi_bootloader.md
@@ -1,0 +1,13 @@
+# Flashing the QSPI Bootloader
+
+You can flash just the QSPI bootloader and install a pre-flashed NVMe afterwards ([NVIDIA docs](https://docs.nvidia.com/jetson/archives/r36.3/DeveloperGuide/SD/FlashingSupport.html#examples)). Upgrading from JetPack 5 to JetPack 6 also requires reflashing the QSPI bootloader.
+
+```
+cd staging/PAB/Linux_for_Tegra/
+sudo ./flash.sh --no-systemimg -c bootloader/generic/cfg/flash_t234_qspi.xml jetson-orin-nano-devkit-super nvme0n1p1
+```
+
+If `./flash.sh` fails, try `l4t_initrd_flash.sh`:
+```
+sudo ./tools/kernel_flash/l4t_initrd_flash.sh -p "--no-systemimg -c bootloader/generic/cfg/flash_t234_qspi.xml" --network usb0 jetson-orin-nano-devkit-super nvme0n1p1
+```

--- a/provision.sh
+++ b/provision.sh
@@ -157,6 +157,13 @@ echo "Installing python3-spidev (manufacturing IMU test)..."
 sudo chroot "$ROOTFS_DIR" apt-get install -y python3-spidev
 sudo chroot "$ROOTFS_DIR" python3 -c "import spidev"  # sanity: importable system-wide
 
+# ── Your packages ───────────────────────────────────────────────────────────
+# Preinstall anything else you want baked into the image here; it lands in the
+# rootfs via the chroot. apt's lists are already updated and PIP_FLAGS is set for
+# the rootfs's pip. For example:
+#   sudo chroot "$ROOTFS_DIR" apt-get install -y vim tmux
+#   sudo chroot "$ROOTFS_DIR" pip3 install "${PIP_FLAGS[@]}" some-package
+
 sudo rm "$ROOTFS_DIR/tmp/$ARK_OS_DEB"
 
 PROVISION_ELAPSED=$(( $(date +%s) - PROVISION_START ))


### PR DESCRIPTION
## Summary

Slim the README to the canonical setup → build → flash flow plus camera-overlay selection, move the remaining advanced topics into their own `docs/` pages, and make the broken-out kernel guide correct and complete.

## Problem

The README started strong and then degraded into a grab-bag "Additional Documentation" section that mixed inline how-tos (clock speeds, Super Mode, manual kernel builds, QSPI bootloader) with doc links. It also documented an internal-only flash-package workflow and a redundant "Install ARK Software" step that `--provision` already covers, and the WiFi example was missing its required target argument. The manual kernel build notes carried two latent bugs from the old README — a wrong Image copy path (`../../kernel/`, which does not exist) and a missing `make modules_install` — so following them by hand flashed a stale or incomplete image. They also said nothing about building out-of-tree modules or iterating on a device-tree overlay without reflashing, despite the doc being named for kernel development.

## Solution

The README now covers only what almost everyone needs: `./setup.sh`, `./build.sh <target> --clean --provision`, an optional WiFi profile, `./flash.sh`, then selecting a camera overlay with `jetson-io` (linking out to the camera doc for sensors and streaming). Advanced content moves to `docs/performance.md` and `docs/kernel_development.md`, both linked from a tight footer; QSPI flashing moves to `docs/qspi_bootloader.md` and is intentionally left unlinked until we decide it is worth surfacing. `provision.sh` gains a clearly marked block for user-added packages, which the build step now points to. The internal flash-package and ARK-OS-install sections are removed, and the WiFi example is corrected to include the target. `docs/kernel_development.md` fixes the Image copy path, adds the missing `make modules_install`, calls out the DTB/overlay placement and module-symlink steps that `build.sh` also performs, and gains sections on out-of-tree modules and on iterating overlays without a reflash; `docs/cameras.md` now notes that a full flash already ships every overlay.
