### PR TITLE
docs(servo-expander): add ARK Servo Expander on JAJ guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See [docs/cameras.md](docs/cameras.md) for supported sensors, overlay names, and
 - [docs/cameras.md](docs/cameras.md) — supported sensors, overlays, and streaming
 - [docs/gpio.md](docs/gpio.md) — 40-pin / I2S header GPIO and boot-time pad defaults
 - [docs/i2c.md](docs/i2c.md) — I2C bus map and scanning
+- [docs/servo_expander.md](docs/servo_expander.md) — PWM / servo output via the ARK Servo Expander (PCA9685) over I2C
 - [docs/10gbe_ethernet.md](docs/10gbe_ethernet.md) — Auvidea M20E 10GbE adapter
 - [docs/performance.md](docs/performance.md) — clock speeds and Super Mode
 - [docs/kernel_development.md](docs/kernel_development.md) — manual kernel builds and device tree changes

--- a/docs/i2c.md
+++ b/docs/i2c.md
@@ -21,3 +21,5 @@ Linux bus numbers come from device-tree aliases and **don't** match the connecto
 | I2C0             | `i2c-1` | 3.3 V | on-module INA3221 `0x40`, USB-PD `0x25` |
 | Camera CSI       | `i2c-2` | 3.3 V | camera sensors |
 | I2C1             | `i2c-7` | 3.3 V | **INA238 `0x45`**, EEPROMs `0x50` / `0x58` |
+
+Adding an **ARK Servo Expander** for PWM? Its PCA9685 also defaults to `0x40` and collides with the INA3221 on `i2c-1` — see [servo_expander.md](servo_expander.md).

--- a/docs/servo_expander.md
+++ b/docs/servo_expander.md
@@ -1,0 +1,78 @@
+# ARK Servo Expander on the Just a Jetson
+
+A Jetson does not provide PWM itself. Instead, you can use an [ARK Servo Expander](https://docs.arkelectron.com/products/accessories/ark-servo-expander) on I2C.
+
+## Wiring
+
+Connect the four I2C signals (GND, SCL, SDA, and 5V) between the JAJ's UART2/I2C0 connector and the expander. See the pinouts:
+
+- [Servo Expander pinout](https://docs.arkelectron.com/products/accessories/ark-servo-expander/pinout)
+- [JAJ UART2/I2C0 connector](https://docs.arkelectron.com/products/embedded-computers/ark-just-a-jetson/pinout#uart2-i2c0-6-pin-jst-gh)
+
+## Pick an address
+
+The expander is a [PCA9685](https://www.nxp.com/docs/en/data-sheet/PCA9685.pdf) and ships at I2C address `0x40`. That address is already taken by the INA3221 power monitor on the Jetson module, so the two will collide and neither works until you move the expander somewhere else.
+
+The address is set by a row of 6 DNP'd resistors on the expander. Short the A0 resistor to change the address to `0x41`. Any address other than `0x40` is fine but `0x41` is the easy choice. If you run several expanders, give each its own address (`0x41`, `0x42`, and so on).
+
+## Check that it shows up
+
+The UART2/I2C0 connector is `/dev/i2c-1` in Linux. Connector names don't line up with kernel bus numbers, so check the [I2C bus map](i2c.md) if you're ever unsure which is which. Scan the bus:
+
+```bash
+sudo i2cdetect -y -r 1
+```
+
+```
+     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
+10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+40: UU 41 -- -- -- -- -- -- -- -- -- -- -- -- -- --
+50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+70: -- -- -- -- -- -- -- --                         
+```
+
+`0x41` is the expander, sitting next to the module's INA3221 at `0x40`. Don't forget the `-r`: without it, `i2cdetect` skips `0x40`–`0x4F` and the bus looks empty even when everything is wired up correctly.
+
+## Drive a servo
+
+PiPCA9685](https://github.com/barulicm/PiPCA9685):
+
+```bash
+git clone https://github.com/barulicm/PiPCA9685.git
+cd PiPCA9685 && cmake -B build && cmake --build build && sudo cmake --install build
+```
+
+Sweep channel 0 between 900, 1500, and 2100 µs at 50 Hz:
+
+```cpp
+#include <unistd.h>
+#include <PiPCA9685/PCA9685.h>
+
+int main() {
+    PiPCA9685::PCA9685 pca{"/dev/i2c-1", 0x41};   // bus 1, reworked address
+
+    constexpr double FREQUENCY_HZ   = 50.0;
+    constexpr double PERIOD_US      = 1'000'000.0 / FREQUENCY_HZ;  // 20000 us
+    constexpr int    PWM_RESOLUTION = 4096;
+
+    constexpr auto to_counts = [](double pulse_us) -> int {
+        return static_cast<int>(pulse_us / PERIOD_US * PWM_RESOLUTION);
+    };
+    constexpr int SERVO_LOW  = to_counts( 900.0);  // 184
+    constexpr int SERVO_MID  = to_counts(1500.0);  // 307
+    constexpr int SERVO_HIGH = to_counts(2100.0);  // 430
+
+    pca.set_pwm_freq(FREQUENCY_HZ);
+    while (true) {
+        pca.set_pwm(0, 0, SERVO_LOW);  usleep(1'000'000);
+        pca.set_pwm(0, 0, SERVO_MID);  usleep(1'000'000);
+        pca.set_pwm(0, 0, SERVO_HIGH); usleep(1'000'000);
+    }
+}
+```
+
+One thing to watch: the PCA9685 keeps time with an internal oscillator that's only accurate to a few percent, so a nominal 50 Hz might really be 48–52 Hz, with the pulse widths shifted to match. Servos tolerate this fine. If you need exact timing, measure the real rate and correct for it.


### PR DESCRIPTION
## Summary

Adds a docs page for driving PWM/servos from a Just a Jetson using an ARK Servo Expander (PCA9685) over I2C on the UART2/I2C0 connector.

## Problem

The JAJ exposes no Linux-usable PWM pins, so getting a PWM output means hanging an external I2C PWM chip off the UART2/I2C0 connector. Doing so hits two non-obvious gotchas that cost real debugging time: the connector labeled I2C0 is `/dev/i2c-1` in Linux (not `i2c-0`/`i2c-7`), and the expander's default address `0x40` collides with the Jetson module's on-board INA3221 already sitting at `0x40` on that same bus — so the expander silently never shows up, compounded by `i2cdetect` skipping `0x40–0x4F` unless you pass `-r`.

## Solution

New `docs/servo_expander.md` covering the connector-to-connector wiring, the address rework (`0x40` → `0x41`), an annotated `i2cdetect -y -r 1` verification, and a minimal PiPCA9685 servo example. Linked from the README docs list and cross-linked from `i2c.md` at the point where the `0x40` collision bites.
