### PR TITLE
fix(packaging): bake default overlays in release flashes, not just flash.sh

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -71,6 +71,8 @@ EEPROM at flash time, a single package flashes **all** Orin Nano/NX variants
 to match the attached module. There is no per-SKU build, so one release per
 carrier covers every module variant.
 
+The package also records the product's default camera overlay(s) (`products/<TARGET>/default_overlays`) in its `ark_flash.conf`; `flash_from_package.sh` bakes them into the DTB at flash time, same as `./flash.sh`.
+
 > This replaces the older massflash (`mfi`) package, which had to pre-bake a single `BOARDSKU` and could therefore flash only one variant — NVIDIA massflash requires every unit to be identical hardware (`tools/kernel_flash/README_initrd_flash.txt`). The trade-off: the flasher builds the flash images on the flashing host, which adds several minutes per run — but `flash_from_package.sh` reuses the previous run's images when the connected module is the same variant, so repeat flashes skip the rebuild.
 
 The output is saved to the project root, e.g. `ark-pab-nvme-super.tar.gz`.

--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -454,12 +454,14 @@ fi
 FLASH_DIR=$(dirname "$FLASH_SCRIPT")          # .../tools/kernel_flash
 L4T_DIR=$(cd "$FLASH_DIR/../.." && pwd)        # .../Linux_for_Tegra
 
-# Flash parameters (board config + storage) travel with the package in
-# ark_flash.conf. Defaults match flash.sh for older packages that predate it.
+# Flash parameters (board config + storage + default DTB overlays) travel with
+# the package in ark_flash.conf. Defaults match flash.sh for older packages that
+# predate it.
 FLASH_TARGET="jetson-orin-nano-devkit-super"
 STORAGE_DEV="nvme0n1p1"
 QSPI_CFG="bootloader/generic/cfg/flash_t234_qspi.xml"
 EXTERNAL_CFG="tools/kernel_flash/flash_l4t_t234_nvme.xml"
+ADDITIONAL_DTB_OVERLAY=""
 if [ -f "$L4T_DIR/ark_flash.conf" ]; then
     # shellcheck disable=SC1091
     source "$L4T_DIR/ark_flash.conf"
@@ -567,11 +569,19 @@ else
     # interrupted run is never mistaken for valid replay state and the marker
     # below provably reflects this run's EEPROM read.
     sudo rm -f "$GEN_MARKER" bootloader/cvm.bin bootloader/chip_info.bin_bak
+    if [ -n "$ADDITIONAL_DTB_OVERLAY" ]; then
+        echo "Baking default device-tree overlay(s) into the image: $ADDITIONAL_DTB_OVERLAY"
+    fi
     # The initrd flasher reads the connected module's EEPROM and picks the matching
     # bootloader + SDRAM config, so one package flashes any Orin Nano/NX variant. It
     # writes the QSPI bootloader (-p) and the rootfs to the external device (-c) in
-    # a single pass.
-    sudo ./tools/kernel_flash/l4t_initrd_flash.sh \
+    # a single pass. ADDITIONAL_DTB_OVERLAY_OPT merges the product's default
+    # overlay(s) into the DTB during image generation; the --flash-only replay
+    # above needs no equivalent because its images already contain the merged DTB.
+    # dtbo basenames carry no spaces, so the unquoted ${var:+NAME=$var} prefix
+    # passes cleanly as a single sudo environment assignment.
+    sudo ${ADDITIONAL_DTB_OVERLAY:+ADDITIONAL_DTB_OVERLAY_OPT=$ADDITIONAL_DTB_OVERLAY} \
+        ./tools/kernel_flash/l4t_initrd_flash.sh \
         --external-device "$STORAGE_DEV" \
         -p "-c ./$QSPI_CFG" \
         -c "./$EXTERNAL_CFG" \

--- a/packaging/generate_flash_package.sh
+++ b/packaging/generate_flash_package.sh
@@ -56,6 +56,28 @@ if [ ! -f "$L4T_DIR/kernel/Image" ]; then
     exit 1
 fi
 
+# Resolve the product's default device-tree overlay(s) exactly like flash.sh and
+# record them in ark_flash.conf, so flash_from_package.sh bakes them into the DTB
+# at flash time too — the default camera must be live on first boot for release
+# flashes, not just local ./flash.sh runs. Each dtbo must have been built into
+# kernel/dtb/ by build.sh; fail loud if not.
+DEFAULT_OVERLAYS_FILE="$ROOT_DIR/products/$TARGET/default_overlays"
+ADDITIONAL_DTB_OVERLAY=""
+if [ -f "$DEFAULT_OVERLAYS_FILE" ]; then
+    while IFS= read -r name; do
+        name="${name%%#*}"
+        name="$(echo "$name" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+        [ -z "$name" ] && continue
+        if [ ! -f "$L4T_DIR/kernel/dtb/$name" ]; then
+            echo "ERROR: default overlay '$name' (from $DEFAULT_OVERLAYS_FILE) is not in" >&2
+            echo "       staging/$TARGET/Linux_for_Tegra/kernel/dtb/ — rebuild with ./build.sh $TARGET" >&2
+            echo "       (is it listed in products/$TARGET/overlay/dtbo.list?)." >&2
+            exit 1
+        fi
+        ADDITIONAL_DTB_OVERLAY="${ADDITIONAL_DTB_OVERLAY:+$ADDITIONAL_DTB_OVERLAY,}$name"
+    done < "$DEFAULT_OVERLAYS_FILE"
+fi
+
 GIT_COMMIT=$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
 GIT_DESCRIBE=$(git -C "$ROOT_DIR" describe --always --dirty --tags 2>/dev/null || echo "unknown")
 GIT_BRANCH=$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
@@ -80,11 +102,14 @@ echo "========================================="
 
 # Flash parameters consumed by flash_from_package.sh. The module variant is read
 # from the module EEPROM at flash time, so nothing here pins a BOARDSKU.
+# ADDITIONAL_DTB_OVERLAY is the product's default overlay set, merged into the
+# base DTB at flash time (see flash.sh for the mechanism).
 sudo tee "$L4T_DIR/ark_flash.conf" >/dev/null <<EOF
 FLASH_TARGET="$FLASH_TARGET"
 STORAGE_DEV="$STORAGE_DEV"
 QSPI_CFG="bootloader/generic/cfg/flash_t234_qspi.xml"
 EXTERNAL_CFG="tools/kernel_flash/flash_l4t_t234_nvme.xml"
+ADDITIONAL_DTB_OVERLAY="$ADDITIONAL_DTB_OVERLAY"
 EOF
 
 sudo tee "$L4T_DIR/BUILD_INFO.txt" >/dev/null <<EOF
@@ -100,6 +125,7 @@ Describe:        $GIT_DESCRIBE
 Target:          $TARGET
 Flash target:    $FLASH_TARGET
 Storage:         $STORAGE_DEV
+Default overlays: ${ADDITIONAL_DTB_OVERLAY:-none}
 Package name:    ${PACKAGE_NAME}.tar.gz
 Module variants: auto-detected at flash time (Orin Nano/NX 4/8/16GB)
 EOF


### PR DESCRIPTION
## Summary

Release flash packages now carry the product's default camera overlay(s), and `flash_from_package.sh` bakes them into the DTB at flash time — matching what local `./flash.sh` runs already do.

## Problem

#92 bakes the product's default camera overlay into the DTB at flash time, but only in the local `flash.sh` path: `generate_flash_package.sh` never recorded `products/<TARGET>/default_overlays` in the package, and `flash_from_package.sh` never passed `ADDITIONAL_DTB_OVERLAY_OPT` to the initrd flasher. A device flashed from a GitHub release therefore boots with no camera overlay applied — the exact regression #92 fixed — and nothing in CI would catch it.

## Solution

`generate_flash_package.sh` resolves `default_overlays` exactly like `flash.sh` (failing loud if a dtbo wasn't built into `kernel/dtb/`, which also validates the overlay names at tag time in CI) and records the list in the package's `ark_flash.conf`. `flash_from_package.sh` reads it and passes `ADDITIONAL_DTB_OVERLAY_OPT` during image generation; the `--flash-only` replay path needs no equivalent because its images already contain the merged DTB. Older packages without the conf entry behave as before.