### PR TITLE
fix(flash): survive udev renaming the flashing gadget mid-configuration

### DIFF
--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -454,6 +454,30 @@ fi
 FLASH_DIR=$(dirname "$FLASH_SCRIPT")          # .../tools/kernel_flash
 L4T_DIR=$(cd "$FLASH_DIR/../.." && pwd)        # .../Linux_for_Tegra
 
+# --- Patch the gadget-rename race in NVIDIA's initrd flasher ---
+
+# Between l4t_initrd_flash_internal.sh's ping_device() listing /sys/class/net
+# and configuring the flashing gadget, udev can rename the interface from its
+# kernel name (usb0) to the persistent enx<mac> name. The stock script's
+# one-shot IP_SET latch is then consumed by the vanished name: the
+# fc00:1:1:<n>::1/fe80::2 host addresses are never added to the renamed
+# interface and the flash dies at "Waiting for device to expose ssh" (seen on
+# desktop hosts; the bench laptops happen to list the interface after the
+# rename and never hit the window). Rewrite the latch into an idempotent
+# per-name check so a later 1 s retry configures the interface under its final
+# name. Runs every flash so caches extracted before this fix get patched too;
+# a no-op once applied, and if NVIDIA restructures the script the pattern
+# simply won't match, leaving stock behavior.
+INTERNAL_FLASH_SCRIPT="$FLASH_DIR/l4t_initrd_flash_internal.sh"
+if sudo grep -qF 'if [ -z "${IP_SET}" ]; then' "$INTERNAL_FLASH_SCRIPT" 2>/dev/null; then
+    echo "Patching interface-rename race in l4t_initrd_flash_internal.sh..."
+    sudo sed -i \
+        -e 's|if \[ -z "\${IP_SET}" \]; then|if ! ip -6 addr show dev "${REPLY}" 2>/dev/null \| grep -q "fc00:1:1:${device_instance}::1"; then|' \
+        -e 's|"\$(sysctl -n "net.ipv6.conf.\${REPLY}.disable_ipv6")" -eq 1|"$(sysctl -n "net.ipv6.conf.${REPLY}.disable_ipv6" 2>/dev/null)" = "1"|' \
+        -e '/^[[:space:]]*IP_SET=0$/d' \
+        "$INTERNAL_FLASH_SCRIPT"
+fi
+
 # Flash parameters (board config + storage + default DTB overlays) travel with
 # the package in ark_flash.conf. Defaults match flash.sh for older packages that
 # predate it.


### PR DESCRIPTION
## Summary
`flash_from_package.sh` now patches a race in NVIDIA's `l4t_initrd_flash_internal.sh` after locating the extracted tree: `ping_device()`'s one-shot `IP_SET` latch becomes an idempotent per-interface-name check, so the flash survives udev renaming the initrd-flash gadget mid-configuration.

## Problem
When the Jetson reboots into the flashing initrd, its USB gadget first appears under the kernel name `usb0` and udev then renames it to the persistent `enx<mac>` name. If NVIDIA's `ping_device()` lists `/sys/class/net` inside that window, it configures the vanished name — `sysctl: cannot stat /proc/sys/net/ipv6/conf/usb0/...`, `line 326: [: : integer expression expected`, three `Cannot find device "usb0"` — and, because `IP_SET` is latched regardless of whether the `ip` commands succeeded, the `fc00:1:1:<n>::1`/`fe80::2` host addresses are never added to the renamed interface. Every subsequent retry skips address setup, `ping6 fe80::1%<iface>` never succeeds, and the flash dies at "Waiting for device to expose ssh ... Timeout" with nothing flashed. Hit deterministically-ish on a desktop host flashing `pab-v3-6.2.2.1`; the bench laptops happen to list the interface after the rename and never see it.

## Solution
After `FLASH_DIR` is resolved (covers fresh extracts and pre-existing caches alike), sed the extracted script: the latch test becomes "does the current matched name already carry `fc00:1:1:<n>::1`", the dead `IP_SET=0` line is dropped, and the ipv6-disabled sysctl probe becomes a string compare with stderr suppressed so a mid-rename probe can't spray errors. A later 1 s retry of `ping_device()` then configures the interface under its final name and the flash proceeds. The patch is guarded by a grep for the stock pattern: it's a no-op once applied, and if NVIDIA restructures the script it simply doesn't match, leaving stock behavior.
