### PR TITLE
fix(flash): survive the off-bus window when polling for the module reset

### DIFF
--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -273,9 +273,12 @@ variant_name() {
 }
 
 # Bus/device number of the connected Jetson's current USB enumeration
-# (e.g. "003-012"). Changes when the chip resets and re-enumerates.
+# (e.g. "003-012"). Changes when the chip resets and re-enumerates; empty
+# while the chip is off the bus mid-reset. lsusb exits nonzero in that
+# window, which must not escape the pipeline: under set -e/pipefail it would
+# abort the script exactly in the state this function exists to observe.
 jetson_devnum() {
-    lsusb -d "0955:${JETSON_USB_PID}" 2>/dev/null | head -1 | awk '{print $2 "-" $4}' | tr -d ':'
+    { lsusb -d "0955:${JETSON_USB_PID}" 2>/dev/null || true; } | head -1 | awk '{print $2 "-" $4}' | tr -d ':'
 }
 
 # The EEPROM probe ends with "reboot recovery", but the MB2 applet only acks
@@ -295,7 +298,8 @@ wait_for_module_reset() {
         now=$(jetson_devnum)
         if [ -n "$now" ] && [ "$now" != "$prev" ]; then
             echo "Module re-enumerated after ${elapsed}s."
-            sleep 2
+            # Let the fresh BootROM settle before an RCM session opens on it.
+            sleep 5
             return 0
         fi
         if [ "$elapsed" -ge 300 ]; then


### PR DESCRIPTION
## Summary
Follow-up to #97: the replay retry died silently right after "Waiting for the module to reset back into recovery mode..." — the reset-wait poll itself killed the script the moment the poked module dropped off the bus. Bench logs end at that line with no error and no retry.

## Problem
`jetson_devnum()` pipes `lsusb -d` output, and when no recovery device is enumerated lsusb exits nonzero; under the script's `set -euo pipefail` the `now=$(jetson_devnum)` assignment in `wait_for_module_reset` then aborts the entire script. The poke-and-retry flow guarantees the first poll lands in exactly that state: after the first replay attempt triggers the applet's deferred reset, the chip is off the bus for about a second while it re-enters BootROM recovery. Both bench runs show the identical footprint — probe OK, attempt 1 dies at `Sending mb1` (the poke, expected), the retry banner prints, then nothing: no "Module re-enumerated", no error, exit taken over by set -e. The landmine predates #97 (any poll during a re-enumeration gap would trip it), but the earlier flows only ever polled while a device was enumerated. Reproduced on the flash host: the unguarded pipeline kills a `set -euo pipefail` shell when the device is absent; the guarded form returns empty and the shell lives.

## Solution
Neutralize lsusb's exit status inside `jetson_devnum` — empty output already means "off the bus" to every caller, including the wait loop's `[ -n "$now" ]` check and the empty-baseline case. Also give the freshly re-enumerated BootROM a 5 s settle (up from 2 s) before the retry opens an RCM session on it.