### PR TITLE
fix(flash): restore probe-clobbered boot binaries before replay

### DIFF
--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -599,6 +599,23 @@ if [ "$REPLAY" = "1" ]; then
         echo "Power-cycle the Jetson into recovery mode and rerun (add --full to regenerate the images from scratch)." >&2
         exit 1
     }
+    # The EEPROM probe regenerates several boot binaries in bootloader/ with
+    # its readinfo/diag-boot flavor, silently replacing the generation-era
+    # set that the saved flash command replays by name (the BR/MB1 BCTs
+    # differ materially). Downloading that mixed set makes the chip reject
+    # the boot chain and reset mid-download — tegrarcm's "might be timeout
+    # in USB write". The signing stage keeps canonical generation-era copies
+    # in bootloader/signed/, which the probe never touches: restore any that
+    # shadow a top-level file before replaying.
+    if [ -d bootloader/signed ]; then
+        echo "Restoring generation-era boot binaries over the probe's..."
+        for _signed in bootloader/signed/*; do
+            _shadowed="bootloader/$(basename "${_signed}")"
+            if [ -f "${_shadowed}" ]; then
+                sudo cp -f "${_signed}" "${_shadowed}"
+            fi
+        done
+    fi
     replay_started=$(date +%s)
     if ! replay_flash; then
         # A fast failure after an EEPROM probe is the applet taking its


### PR DESCRIPTION
## Summary
Final layer of the JAJ replay "might be timeout in USB write" failures (follow-up to #96/#97/#98): the EEPROM probe overwrites generation-era boot binaries in `bootloader/` with its diag-boot flavor, and the replay ships them to the chip. Restore NVIDIA's preserved copies from `bootloader/signed/` after the probe, before replaying. Validated end to end on the production fixture.

## Problem
`nvautoflash.sh --print_boardid` regenerates a dozen files in `bootloader/` with readinfo/diag-boot flavor, including `br_bct_BR.bct` and `mb1_bct_MB1_sigheader.bct.encrypt` (materially different: 13904 vs 17584 bytes). `copy_bootloader` assembles the replay environment from whatever `bootloader/` currently holds (by the names in `flashcmd.txt`), so every post-probe replay downloads a mixed-era boot chain. The chip accepts `bct_br`, rejects the chain, and resets off the bus — under strace the 8 KB BCT write returns success and the next write fails ESHUTDOWN, which tegraflash reports as `might be timeout in USB write` at `Sending mb1`. Deterministic on every Orin Nano 8GB replay (the only variant that probes), and unfixable by rerunning because each rerun re-probes and re-clobbers. #96–#98 fixed real state-machine bugs hiding under the same failure signature (and their poke-and-retry still handles the module's post-probe reset states), but the mixed file set made even a perfectly-timed rcmboot impossible.

## Solution
The signing stage preserves canonical generation-era copies in `bootloader/signed/`, and the probe never touches that directory. Before the replay attempt, copy every `signed/` file that shadows a `bootloader/` top-level file back over it — byte-identical binaries are no-ops, the BCTs are genuinely restored. Validated on the production fixture: the JAJ that had failed 13/13 replays flashed end to end (QSPI + NVMe) from the same cached images with this restore in place.