### PR TITLE
refactor(flash): remove --no-super flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,10 @@ Connect to the USB port, then power on with the Force Recovery button held.
 ```
 ./flash.sh PAB
 ```
-By default `flash.sh` targets NVMe on an Orin Super module. Other layouts:
+By default `flash.sh` targets NVMe. Other storage layouts:
 ```
 ./flash.sh PAB --sdcard     # SD card (NVIDIA dev kit modules)
 ./flash.sh PAB --usb        # USB thumb drive
-./flash.sh PAB --no-super   # non-super module variant
 ```
 
 When flashing completes, SSH in over Micro USB or WiFi:

--- a/flash.sh
+++ b/flash.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Usage: ./flash.sh <TARGET> [--sdcard] [--usb] [--no-super]
+# Usage: ./flash.sh <TARGET> [--sdcard] [--usb]
 #
 # TARGET: PAB | JAJ | PAB_V3
 #
@@ -26,12 +26,9 @@ while [[ $# -gt 0 ]]; do
         --usb)
             STORAGE_DEV="sda"
             shift ;;
-        --no-super)
-            FLASH_TARGET="jetson-orin-nano-devkit"
-            shift ;;
         *)
             echo "Unknown option: $1" >&2
-            echo "Usage: ./flash.sh <PAB | JAJ | PAB_V3> [--sdcard] [--usb] [--no-super]" >&2
+            echo "Usage: ./flash.sh <PAB | JAJ | PAB_V3> [--sdcard] [--usb]" >&2
             exit 1 ;;
     esac
 done
@@ -51,7 +48,7 @@ if [ -z "$TARGET" ]; then
         esac
     else
         echo "ERROR: target required (PAB | JAJ | PAB_V3) when running non-interactively." >&2
-        echo "Usage: ./flash.sh <PAB | JAJ | PAB_V3> [--sdcard] [--usb] [--no-super]" >&2
+        echo "Usage: ./flash.sh <PAB | JAJ | PAB_V3> [--sdcard] [--usb]" >&2
         exit 1
     fi
 fi

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -77,12 +77,6 @@ The package also records the product's default camera overlay(s) (`products/<TAR
 
 The output is saved to the project root, e.g. `ark-pab-nvme-super.tar.gz`.
 
-### Options
-
-| Flag | Description |
-|------|-------------|
-| `--no-super` | Target the non-super module variant |
-
 If the package exceeds 2GB (the GitHub Releases per-file limit), it is automatically split into 1.9GB parts in a `_split/` directory.
 
 ## Flashing from a Release (customer)

--- a/packaging/generate_flash_package.sh
+++ b/packaging/generate_flash_package.sh
@@ -13,7 +13,7 @@
 #
 # Prerequisites: run setup.sh and build.sh <TARGET> --provision first.
 #
-# Usage: ./generate_flash_package.sh <TARGET> [--no-super]
+# Usage: ./generate_flash_package.sh <TARGET>
 
 set -euo pipefail
 
@@ -24,17 +24,16 @@ TARGET=""
 while [[ $# -gt 0 ]]; do
     case $1 in
         PAB|JAJ|PAB_V3) TARGET="$1"; shift ;;
-        --no-super)     FLASH_TARGET="jetson-orin-nano-devkit"; shift ;;
         *)
             echo "Unknown option: $1" >&2
-            echo "Usage: ./generate_flash_package.sh <PAB | JAJ | PAB_V3> [--no-super]" >&2
+            echo "Usage: ./generate_flash_package.sh <PAB | JAJ | PAB_V3>" >&2
             exit 1 ;;
     esac
 done
 
 if [ -z "$TARGET" ]; then
     echo "ERROR: target required (PAB | JAJ | PAB_V3)." >&2
-    echo "Usage: ./generate_flash_package.sh <PAB | JAJ | PAB_V3> [--no-super]" >&2
+    echo "Usage: ./generate_flash_package.sh <PAB | JAJ | PAB_V3>" >&2
     exit 1
 fi
 
@@ -86,10 +85,9 @@ BUILD_HOST=$(hostname)
 BUILD_USER=$(whoami)
 
 TARGET_LOWER=$(echo "$TARGET" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
-PACKAGE_NAME="ark-${TARGET_LOWER}-nvme"
-if [[ "$FLASH_TARGET" == *"-super" ]]; then
-    PACKAGE_NAME="${PACKAGE_NAME}-super"
-fi
+# "-super" is the only flash target now; kept in the name so release asset
+# naming stays consistent across versions.
+PACKAGE_NAME="ark-${TARGET_LOWER}-nvme-super"
 
 echo "========================================="
 echo "  Generating flash package (auto-detect, all module variants)"


### PR DESCRIPTION
## Summary
Remove the `--no-super` flag from `flash.sh` and `generate_flash_package.sh`.

## Problem
The flag (added in #45) switched the flash target to the non-super `jetson-orin-nano-devkit` config, but these carriers only take Orin Nano/NX modules and super is a software mode switch — there is no non-super hardware variant to target, so the flag serves no purpose.

## Solution
Always use the `jetson-orin-nano-devkit-super` flash target (already the default) and drop the flag from both scripts and the docs. The package name keeps its `-super` suffix so release asset naming stays consistent with published releases.