### PR TITLE
fix(setup): install NVIDIA's flash prerequisites at setup time

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -78,6 +78,30 @@ if [ ! -f "$L4T_DIR/kernel/Image" ]; then
     exit 1
 fi
 
+# ── Verify flash prerequisites ───────────────────────────────────────────────
+# setup.sh installs these (NVIDIA's l4t_flash_prerequisites.sh list). NVIDIA's
+# tooling only pre-checks a few of them; any other missing tool (e.g. binutils'
+# `strings`) fails mid-flash, so fail loud here instead.
+FLASH_PREREQS=(abootimg binfmt-support binutils cpio cpp
+    device-tree-compiler dosfstools file gdisk
+    iproute2 iputils-ping lbzip2 libxml2-utils lz4
+    netcat-openbsd nfs-kernel-server openssl
+    parted python-is-python3 python3-yaml qemu-user-static rsync sshpass
+    udev usbutils uuid-runtime whois xmlstarlet xxd zstd zlib1g)
+
+missing=()
+for pkg in "${FLASH_PREREQS[@]}"; do
+    if ! dpkg -s "$pkg" &>/dev/null; then
+        missing+=("$pkg")
+    fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "ERROR: missing flash prerequisites: ${missing[*]}" >&2
+    echo "       Run ./setup.sh (safe to re-run; downloads are cached)." >&2
+    exit 1
+fi
+
 # ── Resolve product default device-tree overlay(s) to bake into the image ────
 # Some products ship a default camera (e.g. PAB = quad IMX219). We hand its dtbo
 # to tegraflash via ADDITIONAL_DTB_OVERLAY, which appends it to OVERLAY_DTB_FILE so

--- a/setup.sh
+++ b/setup.sh
@@ -105,6 +105,23 @@ if [ -d "$SCRIPT_DIR/staging" ]; then
     done
 fi
 
+# Flash prerequisites must land on the HOST: flash.sh runs natively (it needs
+# the USB port), while everything past the re-exec below may run inside the
+# ephemeral build container, where apt installs vanish with it. NVIDIA's
+# l4t_flash_prerequisites.sh list (+ its >= 20.04 additions lz4 and
+# python-is-python3); NVIDIA's flash tooling only pre-checks a few of these —
+# the rest fail mid-flash.
+if [ -z "$IN_BUILD_CONTAINER" ]; then
+    echo "Installing flash prerequisites"
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq abootimg binfmt-support binutils cpio cpp \
+        device-tree-compiler dosfstools file gdisk \
+        iproute2 iputils-ping lbzip2 libxml2-utils lz4 \
+        netcat-openbsd nfs-kernel-server openssl \
+        parted python-is-python3 python3-yaml qemu-user-static rsync sshpass \
+        udev usbutils uuid-runtime whois xmlstarlet xxd zstd zlib1g
+fi
+
 if needs_container; then
     run_in_container "$0" "$@"
 fi


### PR DESCRIPTION
## Summary
Install NVIDIA's flash-prerequisite packages on the host in `setup.sh`, and have `flash.sh` verify they are present and fail loud with a pointer to setup.sh if not.

## Problem
`flash.sh` runs natively on the host (the build container has no USB access) but nothing in the repo installs the host toolchain NVIDIA's initrd-flash tooling needs. NVIDIA's own upfront check in `l4t_initrd_flash.sh` only covers sshpass, abootimg, and zstd — every other required package fails mid-flash with a raw command-not-found. A customer on a fresh Ubuntu 24.04 host hit exactly this: `l4t_initrd_flash_internal.sh` uses `strings` (binutils) to read the kernel version out of the built Image, and binutils is not part of a stock desktop install. Worse, setup.sh's existing apt install can't help: it sits after the `run_in_container` re-exec, so on any non-22.04 host it installs into the ephemeral build container and never touches the host.

## Solution
`setup.sh` gains a host-side install step (before the container re-exec, guarded by `IN_BUILD_CONTAINER` so the in-container pass skips it) with the package list from NVIDIA's `tools/l4t_flash_prerequisites.sh` plus its own >= 20.04 additions, lz4 and python-is-python3. `flash.sh` gets a cheap dpkg presence check that errors with the missing package names and "run ./setup.sh" — covering hosts that ran a pre-change setup.sh — instead of dying mid-flash.