### PR TITLE
fix(setup): install binutils on the flash host

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -105,6 +105,16 @@ if [ -d "$SCRIPT_DIR/staging" ]; then
     done
 fi
 
+# Must install on the HOST, i.e. before the container re-exec below — apt
+# installs after it land in the ephemeral build container. flash.sh runs
+# natively (it needs the USB port), and NVIDIA's initrd-flash tooling uses
+# `strings` (binutils) with no upfront check: on a stock desktop install it
+# fails mid-flash with a raw command-not-found.
+if [ -z "$IN_BUILD_CONTAINER" ]; then
+    echo "Installing flash prerequisites"
+    sudo apt-get install -y -qq binutils
+fi
+
 if needs_container; then
     run_in_container "$0" "$@"
 fi


### PR DESCRIPTION
## Summary
Install binutils from `setup.sh`, on the host side of the container re-exec. Minimal replacement for #101, which was reverted: its strict flash.sh check demanded NVIDIA's whole prerequisite list (python-is-python3 included) on hosts that have been flashing fine without it.

## Problem
NVIDIA's initrd-flash tooling uses `strings` (binutils) to read the kernel version out of the built Image, with no upfront check — on a stock Ubuntu desktop install it fails mid-flash with a raw command-not-found. This is the one gap a customer actually hit; every other tool the flash needs has either been present in practice or is covered by NVIDIA's own sshpass/abootimg/zstd pre-check. setup.sh's existing apt install can't cover it because it sits after the `run_in_container` re-exec, so on non-22.04 hosts it installs into the ephemeral build container and never touches the host.

## Solution
Add a binutils install in setup.sh's host-side section, before the container re-exec, guarded by `IN_BUILD_CONTAINER` so the in-container pass skips it. No verification block in flash.sh.