### PR TITLE
docs(share_wifi): document the WiFi sharing scripts and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See [docs/cameras.md](docs/cameras.md) for supported sensors, overlay names, and
 - [docs/i2c.md](docs/i2c.md) — I2C bus map and scanning
 - [docs/servo_expander.md](docs/servo_expander.md) — PWM / servo output via the ARK Servo Expander (PCA9685) over I2C
 - [docs/10gbe_ethernet.md](docs/10gbe_ethernet.md) — Auvidea M20E 10GbE adapter
+- [docs/share_wifi.md](docs/share_wifi.md) — share the host PC's WiFi with the Jetson over USB
 - [docs/performance.md](docs/performance.md) — clock speeds and Super Mode
 - [docs/kernel_development.md](docs/kernel_development.md) — manual kernel builds and device tree changes
 - [docs/build_host.md](docs/build_host.md) — why the build pins to Ubuntu 22.04

--- a/docs/share_wifi.md
+++ b/docs/share_wifi.md
@@ -1,26 +1,41 @@
-These notes provide instructions on how to share the wifi connection from your host PC to the jetson via RNDIS over micro USB.
-You may need to change the interface names (enxf69cefb27da8 and wlo1) and subnet (192.168.55.0/24).
+# Sharing WiFi over USB
 
-#### Desktop
+`scripts/share_wifi.sh` shares your host PC's WiFi connection with the Jetson over the micro-USB (RNDIS) link, so the Jetson gets internet access without a network connection of its own.
+
+The Jetson's side is already set up out of the box: L4T's USB device mode assigns the Jetson 192.168.55.1, hands the host 192.168.55.100 over DHCP, and adds a low-priority default route back through the host. The script fills in the host side by enabling IPv4 forwarding and NAT-masquerading the Jetson's traffic out through the WiFi interface.
+
+## Start sharing
+
+With the Jetson booted and connected over USB, run on the host:
+
 ```
 ./scripts/share_wifi.sh
 ```
 
-Reset the state on the desktop
-```
-./scripts/stop_share_wifi.sh
-```
+The script auto-detects the USB link (the interface with an address in 192.168.55.0/24) and the WiFi interface (name starting with `wl`). If it can't find the USB link, make sure the Jetson has finished booting and shows up in `ip addr`.
 
-#### Jetson
-Test internet connection
+Verify from the Jetson:
+
 ```
 ping 8.8.8.8
 ```
 
-Connect to your WiFi network if available
+The USB link does not carry DNS, so if `ping 8.8.8.8` works but hostnames don't resolve, point the Jetson at a nameserver:
+
 ```
-SSID="<your_ssid>"
-PASSWORD="<your_password>"
-sudo nmcli con add type wifi ifname '*' con-name "$SSID" autoconnect yes ssid "$SSID" wifi-sec.key-mgmt wpa-psk wifi-sec.psk "$PASSWORD"
-sudo nmcli con up $SSID
+sudo resolvectl dns l4tbr0 8.8.8.8
 ```
+
+## Stop sharing
+
+```
+./scripts/stop_share_wifi.sh
+```
+
+This flushes the iptables rules and disables IP forwarding.
+
+## Caveats
+
+- Both scripts edit the host's live iptables state: `share_wifi.sh` flushes the `FORWARD` chain and `stop_share_wifi.sh` flushes all tables, so existing firewall rules (ufw, docker) are cleared. Re-add or restart those services afterwards if you rely on them.
+- Nothing persists across a host reboot — rerun `share_wifi.sh` as needed.
+- If the Jetson can join a WiFi network directly, that's simpler: see [Add WiFi](../README.md#3-add-wifi-optional) in the README.

--- a/docs/share_wifi.md
+++ b/docs/share_wifi.md
@@ -1,6 +1,6 @@
 # Sharing WiFi over USB
 
-`scripts/share_wifi.sh` shares your host PC's WiFi connection with the Jetson over the micro-USB (RNDIS) link, so the Jetson gets internet access without a network connection of its own.
+`scripts/share_wifi.sh` shares your host PC's WiFi connection with the Jetson over the USB network link, so the Jetson gets internet access without a network connection of its own.
 
 The Jetson's side is already set up out of the box: L4T's USB device mode assigns the Jetson 192.168.55.1, hands the host 192.168.55.100 over DHCP, and adds a low-priority default route back through the host. The script fills in the host side by enabling IPv4 forwarding and NAT-masquerading the Jetson's traffic out through the WiFi interface.
 


### PR DESCRIPTION
## Summary
Rewrites `docs/share_wifi.md` to properly document `scripts/share_wifi.sh` and `scripts/stop_share_wifi.sh`, and links it from the README's More documentation section.

## Problem
The share-wifi doc existed as an unlinked stub: it wasn't reachable from the README, and it told users to hand-edit interface names and subnet even though the script auto-detects both. It also didn't explain what the scripts actually do or their side effects.

## Solution
Rewrite the doc to match the current scripts: how detection works, what the host side sets up (IP forwarding + NAT), what the Jetson already provides out of the box (address, DHCP, default route via 192.168.55.100 — verified in L4T's `nv-l4t-usb-device-mode-config.sh`), the missing-DNS gotcha with a one-line fix, and caveats (iptables flushing clobbers existing firewall rules, nothing persists across reboot). Add the doc to the README's More documentation list.