### PR TITLE
refactor(build): default to a full provisioned build; add --fast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,15 +127,17 @@ jobs:
         run: ccache -z
 
       - name: Build kernel
-        # Tag builds provision with the pinned ARK-OS deb; provision.sh falls back
+        # Provisioning (ARK-OS + the pinned camera stack) is the build default now;
+        # tag builds keep --provision explicit for clarity. provision.sh falls back
         # loudly to the newest published (pre)release if the pin isn't published. The
-        # draft release ships a flashable, provisioned image; promoting it to
-        # published is a GitHub toggle with no rebuild. PR/main builds only compile-check.
+        # draft release ships a flashable, provisioned image; promoting it to published
+        # is a GitHub toggle with no rebuild. PR/main builds only compile-check, so
+        # --no-provision skips the ~6 min provision and its NVIDIA/GitHub network deps.
         run: |
           if [ -n "${{ steps.tag.outputs.target }}" ]; then
             ./build.sh ${{ steps.tag.outputs.target }} --provision
           else
-            ./build.sh PAB
+            ./build.sh PAB --no-provision
           fi
 
       - name: ccache stats

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Download the BSP, root filesystem, and kernel source tarballs (one time):
 
 ### 2. Build
 ```
-./build.sh PAB --clean --provision
+./build.sh PAB
 ```
 - Targets are `PAB`, `JAJ`, `PAB_V3`, or `all`.
-- `--clean` wipes `staging/{TARGET}/` and re-stages from scratch.
-- `--provision` preinstalls [ARK-OS](https://github.com/ARK-Electronics/ARK-OS) and tooling into the image. Omit it for a bare image. To bake in your own packages, edit [`provision.sh`](provision.sh).
+- By default a build re-stages `staging/{TARGET}/` from scratch and provisions the image — it preinstalls [ARK-OS](https://github.com/ARK-Electronics/ARK-OS) and tooling. To bake in your own packages, edit [`provision.sh`](provision.sh).
+- `--fast` reuses the existing staged tree and just recompiles the kernel/device tree, for quick iteration after a full build.
+- `--no-provision` builds a bare image (no ARK-OS). `--clean` and `--provision` are still accepted but are the default now.
 
 ### 3. Add WiFi (optional)
 Bake a WiFi profile into the image before flashing:

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-# Usage: ./build.sh <PAB|JAJ|PAB_V3|all> [--clean] [--provision]
-#   --clean      wipe staging/{TARGET}/ and re-stage from downloads before building
-#   --provision  install ARK-OS into the rootfs (staging only: first build or --clean)
+# Usage: ./build.sh <PAB|JAJ|PAB_V3|all> [--fast] [--no-provision]
+#   (default)             wipe staging/{TARGET}/, re-stage, provision, then build
+#   --fast                reuse the existing staged tree — recompile the kernel/DT
+#                         only, no re-stage and no re-provision (needs a prior build)
+#   --no-provision        re-stage and build a bare image, skipping provisioning
+#   --clean, --provision  accepted but redundant now — they are the default
 #
-# First build per target stages the L4T tree under its own staging/{TARGET}/;
-# later builds just recompile. Products share no mutable state.
+# A full build (the default) stages the L4T tree under its own staging/{TARGET}/,
+# provisions the rootfs (ARK-OS + the pinned camera stack), then compiles the
+# kernel. --fast skips straight to the compile against an existing tree. Products
+# share no mutable state.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export ARK_JETSON_KERNEL_DIR="$SCRIPT_DIR"
@@ -15,23 +20,30 @@ source "$SCRIPT_DIR/scripts/check_bsp.sh"
 
 # ── Argument parsing ────────────────────────────────────────────────────────
 
-CLEAN=0
-PROVISION=0
+CLEAN=1
+PROVISION=1
+FAST=0
 TARGET=""
 
 for arg in "$@"; do
     case "$arg" in
         PAB|JAJ|PAB_V3) TARGET="$arg" ;;
         all)            TARGET="all" ;;
-        --clean)        CLEAN=1 ;;
-        --provision)    PROVISION=1 ;;
+        --fast)         FAST=1 ;;
+        --no-provision) PROVISION=0 ;;
+        --clean)        CLEAN=1 ;;      # the default now; still accepted so old commands work
+        --provision)    PROVISION=1 ;;  # the default now; still accepted so old commands work
         *)
             echo "Invalid argument: $arg" >&2
-            echo "Usage: $0 <PAB | JAJ | PAB_V3 | all> [--clean] [--provision]" >&2
+            echo "Usage: $0 <PAB | JAJ | PAB_V3 | all> [--fast] [--no-provision]" >&2
             exit 1
             ;;
     esac
 done
+
+# --fast reuses the staged tree as-is: no wipe, no (re)provision. It wins over the
+# clean/provision defaults regardless of the order flags were given in.
+[ "$FAST" -eq 1 ] && { CLEAN=0; PROVISION=0; }
 
 if [ -z "$TARGET" ]; then
     if [ -t 0 ]; then
@@ -51,7 +63,7 @@ if [ -z "$TARGET" ]; then
         esac
     else
         echo "ERROR: target required (PAB | JAJ | PAB_V3 | all) when running non-interactively." >&2
-        echo "Usage: $0 <PAB | JAJ | PAB_V3 | all> [--clean] [--provision]" >&2
+        echo "Usage: $0 <PAB | JAJ | PAB_V3 | all> [--fast] [--no-provision]" >&2
         exit 1
     fi
 fi
@@ -102,8 +114,8 @@ if [ "$TARGET" = "all" ]; then
         echo "  Building $t"
         echo "========================================="
         ARGS=("$t")
-        [ "$CLEAN" -eq 1 ] && ARGS+=("--clean")
-        [ "$PROVISION" -eq 1 ] && ARGS+=("--provision")
+        [ "$FAST" -eq 1 ] && ARGS+=("--fast")
+        [ "$FAST" -eq 0 ] && [ "$PROVISION" -eq 0 ] && ARGS+=("--no-provision")
         "$0" "${ARGS[@]}" || exit $?
     done
     exit 0
@@ -115,8 +127,8 @@ export TARGET
 # doesn't re-prompt.
 if needs_container; then
     CONTAINER_ARGS=("$TARGET")
-    [ "$CLEAN" -eq 1 ] && CONTAINER_ARGS+=("--clean")
-    [ "$PROVISION" -eq 1 ] && CONTAINER_ARGS+=("--provision")
+    [ "$FAST" -eq 1 ] && CONTAINER_ARGS+=("--fast")
+    [ "$FAST" -eq 0 ] && [ "$PROVISION" -eq 0 ] && CONTAINER_ARGS+=("--no-provision")
     run_in_container "$0" "${CONTAINER_ARGS[@]}"
 fi
 
@@ -161,7 +173,16 @@ export CROSS_COMPILE=$HOME/l4t-gcc/aarch64--glibc--stable-2022.08-1/bin/aarch64-
 export KERNEL_HEADERS="$SOURCE_DIR/kernel/kernel-jammy-src"
 export INSTALL_MOD_PATH="$L4T_DIR/rootfs/"
 
-# ── Stage target (first build only) ────────────────────────────────────────
+# --fast reuses an existing staged tree; there's nothing to reuse if it's absent.
+# Fail loud rather than silently staging a bare, unprovisioned tree.
+if [ "$FAST" -eq 1 ] && [ ! -d "$L4T_DIR" ]; then
+    echo "ERROR: --fast needs an existing staged tree, but $L4T_DIR is missing." >&2
+    echo "       Run './build.sh $TARGET' first (stages + provisions), then use" >&2
+    echo "       --fast for quick kernel/device-tree rebuilds." >&2
+    exit 1
+fi
+
+# ── Stage target (skipped by --fast) ────────────────────────────────────────
 
 if [ ! -d "$L4T_DIR" ]; then
     echo "========================================="
@@ -196,7 +217,7 @@ if [ ! -d "$L4T_DIR" ]; then
     if [ "$PROVISION" -eq 1 ]; then
         PROVISION_SCRIPT="$SCRIPT_DIR/provision.sh"
         if [ ! -f "$PROVISION_SCRIPT" ]; then
-            echo "ERROR: --provision specified but provision.sh not found." >&2
+            echo "ERROR: provisioning requested but provision.sh not found." >&2
             exit 1
         fi
 
@@ -267,10 +288,7 @@ if [ ! -d "$L4T_DIR" ]; then
     echo "Staging complete for $TARGET."
     echo ""
 else
-    if [ "$PROVISION" -eq 1 ]; then
-        echo "WARNING: --provision has no effect — staging/$TARGET/ already exists." >&2
-        echo "         Use --clean --provision to re-stage with provisioning." >&2
-    fi
+    echo "Reusing existing staged tree for $TARGET (--fast): skipping re-stage and provisioning."
 fi
 
 # ── BSP version check ──────────────────────────────────────────────────────

--- a/docs/cameras.md
+++ b/docs/cameras.md
@@ -104,7 +104,7 @@ v4l2-ctl --set-fmt-video=width=3840,height=2160,pixelformat=RG10 --stream-mmap -
 
 ### GStreamer
 
-Images built with `--provision` already ship the Tegra GStreamer plugins (`nvarguscamerasrc`, `nvvidconv`, `nvv4l2*`) via `nvidia-l4t-gstreamer`. Install `nvidia-jetpack` only if you also need the full CUDA/TensorRT compute stack.
+A provisioned image (the build default) already ships the Tegra GStreamer plugins (`nvarguscamerasrc`, `nvvidconv`, `nvv4l2*`) via `nvidia-l4t-gstreamer`. Install `nvidia-jetpack` only if you also need the full CUDA/TensorRT compute stack.
 
 UDP h.264 stream (replace IP/port):
 ```
@@ -131,4 +131,4 @@ gst-launch-1.0 nvarguscamerasrc sensor-id=1 ...
 
 ## Known Issues
 
-**JetPack 6.2.2 / R36.5.0 Argus regression** (bench-reproduced on PAB_V3/Orin NX with dual IMX219): every `nvarguscamerasrc` teardown errors (`CANCELLED` / `Argus Correctable Error Status`), and roughly 1 in 60–120 camera relaunches fails outright — no frames, then a nvargus-daemon segfault and a ~40 s video outage. Introduced by NVIDIA in the L4T 36.4.7 userspace refresh, still present in 36.5.0; the kernel/device tree/RCE firmware are not involved, and NVIDIA's forum workaround (keeping the camera RTCPU powered) does **not** prevent it on Orin NX. Fix shipped in this repo: `--provision` pins the camera userspace stack (gstreamer/camera/multimedia debs) to the last good release via `NV_CAMERA_STACK_VERSION` in `versions.env`. Full evidence, repro protocol, and bench data: [argus_relaunch_regression.md](argus_relaunch_regression.md) (issue [#107](https://github.com/ARK-Electronics/ark_jetson_kernel/issues/107)).
+**JetPack 6.2.2 / R36.5.0 Argus regression** (bench-reproduced on PAB_V3/Orin NX with dual IMX219): every `nvarguscamerasrc` teardown errors (`CANCELLED` / `Argus Correctable Error Status`), and roughly 1 in 60–120 camera relaunches fails outright — no frames, then a nvargus-daemon segfault and a ~40 s video outage. Introduced by NVIDIA in the L4T 36.4.7 userspace refresh, still present in 36.5.0; the kernel/device tree/RCE firmware are not involved, and NVIDIA's forum workaround (keeping the camera RTCPU powered) does **not** prevent it on Orin NX. Fix shipped in this repo: provisioning (the build default) pins the camera userspace stack (gstreamer/camera/multimedia debs) to the last good release via `NV_CAMERA_STACK_VERSION` in `versions.env`. Full evidence, repro protocol, and bench data: [argus_relaunch_regression.md](argus_relaunch_regression.md) (issue [#107](https://github.com/ARK-Electronics/ark_jetson_kernel/issues/107)).

--- a/packaging/generate_flash_package.sh
+++ b/packaging/generate_flash_package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Generates a self-contained flash package (.tar.gz) from a built (and ideally
-# --provision'd) staging tree. The package IS the staged Linux_for_Tegra tree
+# Generates a self-contained flash package (.tar.gz) from a built, provisioned
+# staging tree. The package IS the staged Linux_for_Tegra tree
 # (minus the kernel build sources); flash_from_package.sh flashes it with
 # NVIDIA's initrd flasher, which reads the connected module's EEPROM at flash
 # time and selects the matching bootloader + SDRAM config. One package therefore
@@ -11,7 +11,7 @@
 # BOARDSKU and could only flash that one module: NVIDIA massflash requires every
 # unit be identical hardware (tools/kernel_flash/README_initrd_flash.txt).
 #
-# Prerequisites: run setup.sh and build.sh <TARGET> --provision first.
+# Prerequisites: run setup.sh and build.sh <TARGET> first.
 #
 # Usage: ./generate_flash_package.sh <TARGET>
 

--- a/provision.sh
+++ b/provision.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Rootfs provisioning — runs during staging when build.sh is given --provision.
+# Rootfs provisioning — runs during staging on a full build (skipped by build.sh --no-provision).
 # Env: ROOTFS_DIR (the staged rootfs), TARGET (PAB|JAJ|PAB_V3).
 #
 # /proc, /sys, /dev are bind-mounted and DNS is set up; /run is not, so ARK-OS's

--- a/versions.env
+++ b/versions.env
@@ -29,7 +29,7 @@ TOOLCHAIN_URL="https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v
 
 unset _release_lc _release_path _release_tag
 
-# ARK-OS payload is installed only with --provision
+# ARK-OS payload is installed on a full build (skipped by build.sh --no-provision)
 # JETSON_STATS_VERSION must match the canonical pin in ARK-OS packaging/versions.env
 # (MAVSDK needs no pin here: it is bundled inside the ark-os deb since ARK-OS#75)
 #
@@ -38,7 +38,7 @@ JETSON_STATS_VERSION="4.3.2"   # jtop daemon + client, installed system-wide via
 
 # Camera userspace stack: nvidia-l4t-gstreamer (repo `common` pool; not in the BSP deb
 # set apply_binaries installs) plus nvidia-l4t-camera/-multimedia/-multimedia-utils
-# (t234 pool; BSP-installed, replaced by --provision). Pinned BELOW the BSP on purpose:
+# (t234 pool; BSP-installed, replaced during provisioning). Pinned BELOW the BSP on purpose:
 # the 36.4.7+/36.5.0 Argus userspace regressed — dirty session teardowns and
 # nvargus-daemon SEGV on camera relaunch — while the same cycling is clean with this
 # stack on the stock 36.5.0 kernel/RCE firmware (bench-validated 2026-07-17 on


### PR DESCRIPTION
## Summary

Invert `build.sh`'s defaults so a bare `./build.sh <TARGET>` produces a full, provisioned, ship-ready image. Quick rebuilds and bare images become explicit opt-outs (`--fast`, `--no-provision`).

## Problem

`--clean` and `--provision` were opt-in, so the common and correctness-critical case — a provisioned image with ARK-OS and the pinned camera stack — required remembering two flags, while the rare case (a fast kernel-only rebuild) was the flagless default. Forgetting the flags silently produced a stock, unprovisioned image, and `--provision` on an already-staged tree quietly no-op'd. This is the class of confusion behind #110: a build that ships the stock 36.5.0 camera stack instead of the pinned `+ark1` one.

## Solution

The default is now clean + provision + build. Two opt-outs:

- `--fast` — reuse the existing staged tree, recompile the kernel/device tree only. Errors if nothing is staged, so it can't silently ship an unprovisioned image.
- `--no-provision` — fresh stage + build, skip provisioning (the compile-check path).

`--clean`/`--provision` remain accepted as harmless no-ops. CI's PR/main compile-check moves to `--no-provision` so it no longer provisions (or hits NVIDIA/GitHub) on every push; tag builds keep `--provision` explicit. Comments and docs referencing the old opt-in flags are updated to match.
