### PR TITLE
fix(build): add quiet to the kernel command line

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -612,20 +612,42 @@ done
 # suppresses the AER lines (KERN_WARNING) while keeping KERN_ERR and worse. Only the
 # default entry is patched, but jetson-io copies its APPEND verbatim into the entry it
 # writes, so a camera-overlay switch stays quiet too.
-echo "Ensuring 'quiet' is on the extlinux kernel command line..."
-sudo python3 - "$L4T_DIR/rootfs/boot/extlinux/extlinux.conf" <<'PY'
+#
+# log_buf_len covers what quiet does not: a suppressed message still enters the ring
+# buffer, and the 256K default wrapped inside a minute of boot on that bench, so dmesg
+# no longer reached back to the lines the fixture tests read.
+echo "Ensuring 'quiet log_buf_len=4M' is on the extlinux kernel command line..."
+sudo python3 - "$L4T_DIR/rootfs/boot/extlinux/extlinux.conf" quiet log_buf_len=4M <<'PY'
 import re, sys
-path = sys.argv[1]
+path, tokens = sys.argv[1], sys.argv[2:]
 lines = open(path).read().splitlines(keepends=True)
 appends = [i for i, line in enumerate(lines) if re.match(r'[ \t]*APPEND ', line)]
 if len(appends) != 1:
     sys.exit("ERROR: expected exactly one active APPEND line in extlinux.conf, got %d; "
              "re-check the BSP's boot configuration before shipping." % len(appends))
 i = appends[0]
-if not re.search(r'(?:^|\s)quiet(?:\s|$)', lines[i].rstrip('\n')):
-    lines[i] = lines[i].rstrip('\n') + ' quiet\n'
+append = lines[i].rstrip('\n')
+for token in tokens:
+    key = token.split('=')[0]
+    if not re.search(r'(?:^|\s)%s(?:=|\s|$)' % re.escape(key), append):
+        append += ' ' + token
+if append + '\n' != lines[i]:
+    lines[i] = append + '\n'
     open(path, 'w').writelines(lines)
 PY
+
+# quiet only holds until systemd-sysctl runs. nvidia-l4t-configs ships
+# /etc/sysctl.d/30-nv-console-messages.conf with kernel.printk = 6 6 1 7, which puts the
+# console threshold back to 6 a few seconds into userspace and the whole KERN_WARNING
+# flood back on the wire: measured on a JAJ fixture, quiet alone still gave a 1.77 MB
+# boot console. Win on sort order rather than editing their conffile. The value is stock
+# Ubuntu's, from the 10-console-messages.conf that 30- overrode.
+echo "Installing the console loglevel sysctl drop-in..."
+sudo tee "$L4T_DIR/rootfs/etc/sysctl.d/99-ark-console-quiet.conf" >/dev/null <<'EOF'
+# Console threshold 4: warnings and anything less severe stay off the 115200 console that
+# the kernel blocks on. KERN_ERR and worse still print; dmesg still records everything.
+kernel.printk = 4 4 1 7
+EOF
 
 # ── Record build metadata ───────────────────────────────────────────────────
 

--- a/build.sh
+++ b/build.sh
@@ -602,6 +602,32 @@ for dir in "$L4T_DIR/rootfs/boot" "$L4T_DIR/kernel/dtb"; do
     done
 done
 
+# ── Quiet the serial console ────────────────────────────────────────────────
+
+# The BSP boots a verbose console (CONFIG_CONSOLE_LOGLEVEL_DEFAULT=7) on a 115200
+# UART, and printk to a serial console is synchronous: a driver logging faster than
+# ~11.5 kB/s throttles the whole kernel. A PCIe AER correctable-error storm on a
+# marginal link does exactly that, starving systemd until RuntimeWatchdogSec resets
+# the board. quiet drops the console threshold to CONSOLE_LOGLEVEL_QUIET (4), which
+# suppresses the AER lines (KERN_WARNING) while keeping KERN_ERR and worse — unlike
+# loglevel=1, which would hide real failures too. The ring buffer is untouched, so
+# dmesg still has everything. jetson-io copies the default entry's APPEND verbatim,
+# so the entry it generates inherits this.
+echo "Ensuring 'quiet' is on the extlinux kernel command line..."
+sudo python3 - "$L4T_DIR/rootfs/boot/extlinux/extlinux.conf" <<'PY'
+import re, sys
+path = sys.argv[1]
+lines = open(path).read().splitlines(keepends=True)
+appends = [i for i, line in enumerate(lines) if re.match(r'[ \t]*APPEND ', line)]
+if len(appends) != 1:
+    sys.exit("ERROR: expected exactly one active APPEND line in extlinux.conf, got %d; "
+             "re-check the BSP's boot configuration before shipping." % len(appends))
+i = appends[0]
+if not re.search(r'(?:^|\s)quiet(?:\s|$)', lines[i].rstrip('\n')):
+    lines[i] = lines[i].rstrip('\n') + ' quiet\n'
+    open(path, 'w').writelines(lines)
+PY
+
 # ── Record build metadata ───────────────────────────────────────────────────
 
 BUILD_COMMIT=$ARK_BUILD_COMMIT

--- a/build.sh
+++ b/build.sh
@@ -609,8 +609,9 @@ done
 # ~11.5 kB/s throttles the whole kernel. A PCIe AER correctable-error storm on a
 # marginal link does exactly that, starving systemd until RuntimeWatchdogSec resets
 # the board. quiet drops the console threshold to CONSOLE_LOGLEVEL_QUIET (4), which
-# suppresses the AER lines (KERN_WARNING) while keeping KERN_ERR and worse. jetson-io
-# copies the default entry's APPEND verbatim, so the entry it generates inherits this.
+# suppresses the AER lines (KERN_WARNING) while keeping KERN_ERR and worse. Only the
+# default entry is patched, but jetson-io copies its APPEND verbatim into the entry it
+# writes, so a camera-overlay switch stays quiet too.
 echo "Ensuring 'quiet' is on the extlinux kernel command line..."
 sudo python3 - "$L4T_DIR/rootfs/boot/extlinux/extlinux.conf" <<'PY'
 import re, sys

--- a/build.sh
+++ b/build.sh
@@ -609,10 +609,8 @@ done
 # ~11.5 kB/s throttles the whole kernel. A PCIe AER correctable-error storm on a
 # marginal link does exactly that, starving systemd until RuntimeWatchdogSec resets
 # the board. quiet drops the console threshold to CONSOLE_LOGLEVEL_QUIET (4), which
-# suppresses the AER lines (KERN_WARNING) while keeping KERN_ERR and worse — unlike
-# loglevel=1, which would hide real failures too. The ring buffer is untouched, so
-# dmesg still has everything. jetson-io copies the default entry's APPEND verbatim,
-# so the entry it generates inherits this.
+# suppresses the AER lines (KERN_WARNING) while keeping KERN_ERR and worse. jetson-io
+# copies the default entry's APPEND verbatim, so the entry it generates inherits this.
 echo "Ensuring 'quiet' is on the extlinux kernel command line..."
 sudo python3 - "$L4T_DIR/rootfs/boot/extlinux/extlinux.conf" <<'PY'
 import re, sys


### PR DESCRIPTION
## Summary

Quiets the kernel's serial console on PAB, JAJ and PAB_V3, and widens the ring buffer so a flood no longer costs us the boot record. Three parts: `quiet` and `log_buf_len=4M` on the extlinux `APPEND`, and a sysctl drop-in that keeps the console threshold down once userspace is running.

## Problem

The BSP boots with `CONFIG_CONSOLE_LOGLEVEL_DEFAULT=7` against `console=ttyTCU0,115200`. `printk()` to a serial console is synchronous — it busy-waits for the UART FIFO — so the kernel is hard-capped at 11520 B/s of log output, and anything logging faster throttles the entire system.

A marginal PCIe link makes that concrete. AER correctable errors (`RxErr`, `BadDLLP`) are harmless to data — the link replays and NVMe keeps working — but each event emits three log lines, ~400 bytes, so roughly 35 ms of blocking UART transmission apiece. On the bench that measured 11441 B/s against the 11520 B/s ceiling: the kernel ran at about 1/5 real time, idle load sat near 5, and `RuntimeWatchdogSec=120` reset the board every couple of minutes because PID 1 could not pet the watchdog.

`quiet` on its own does not hold. L4T ships `/etc/sysctl.d/30-nv-console-messages.conf` — `kernel.printk = 6 6 1 7`, a `nvidia-l4t-configs` conffile — which `systemd-sysctl` applies a few seconds into userspace and which puts the console threshold back to 6. Measured on a JAJ fixture: with `quiet` on `/proc/cmdline`, `/proc/sys/kernel/printk` still read `6 6 1 7` and the boot console still carried 1.77 MB across 4289 AER lines. It only ever bought the pre-userspace window.

Suppression also does nothing for the ring buffer: every message still lands there, and at the 256K default the buffer wrapped inside a minute of boot — at 1 min uptime it spanned six seconds — so `dmesg` no longer reached the driver probe lines the fixture tests read back.

## Solution

`quiet` sets the console threshold to `CONSOLE_LOGLEVEL_QUIET` (4). `suppress_message_printing()` drops a message when `level >= console_loglevel`, and correctable AER logs at `KERN_WARNING` (4) on every line — `aer.c:687` and `aer.c:719` — so all of it is suppressed. `KERN_ERR` and worse still reach the console, unlike `loglevel=1`, which would also hide uncorrectable AER, filesystem errors and OOM kills.

`99-ark-console-quiet.conf` carries the same threshold into userspace, winning on sort order rather than editing NVIDIA's conffile. Its value is stock Ubuntu's, from the `10-console-messages.conf` that 30- overrode. With both in place the JAJ boot console went 1.77 MB → 52 kB, zero AER lines.

`log_buf_len=4M` keeps `dmesg` and `journalctl -k` usable through a flood, which is what the bench reads when a run needs explaining after the fact.

Raising the console baud rate would relieve the same pressure, but the bench depends on long FTDI runs at 115200.

Patched at the extlinux layer rather than `CMDLINE_ADD` so it can be flipped on a unit without a reflash. jetson-io copies the default entry's `APPEND` verbatim (`extlinux.py:67`, `:100`), so the entry it generates on the fixture inherits it. Runs outside the staging block and is idempotent, so `--fast` rebuilds pick it up too, and it aborts the build if the file no longer has exactly one active `APPEND` line.
