### PR TITLE
fix(pab): sequence J33 VBUS with the USB host, not the bootloader

### DIFF
--- a/products/PAB/device_tree/bootloader/tegra234-mb1-bct-gpio-p3767-dp-a03.dtsi
+++ b/products/PAB/device_tree/bootloader/tegra234-mb1-bct-gpio-p3767-dp-a03.dtsi
@@ -53,7 +53,6 @@
 				TEGRA234_MAIN_GPIO(P, 6)
 				TEGRA234_MAIN_GPIO(R, 4)
 				TEGRA234_MAIN_GPIO(R, 5)
-				TEGRA234_MAIN_GPIO(N, 1)
 				TEGRA234_MAIN_GPIO(G, 0)
 				TEGRA234_MAIN_GPIO(G, 7)
 				TEGRA234_MAIN_GPIO(L, 2)
@@ -67,6 +66,11 @@
 				TEGRA234_MAIN_GPIO(AC, 6)
 				>;
 			gpio-output-low = <
+				/* J33 VBUS enable (U20). Held off through the bootloader so a SuperSpeed
+				 * device there powers up against a live host, not tens of seconds before
+				 * one exists. The kernel owns the pin from probe on — see
+				 * vdd_5v0_usbss0 in ark-PAB-overrides.dtsi. */
+				TEGRA234_MAIN_GPIO(N, 1)
 				TEGRA234_MAIN_GPIO(Y, 4)
 				TEGRA234_MAIN_GPIO(H, 0)
 				TEGRA234_MAIN_GPIO(H, 6)

--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/nv-platform/ark-PAB-overrides.dtsi
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/nv-platform/ark-PAB-overrides.dtsi
@@ -14,11 +14,14 @@
 	};
 
 	/* VBUS for the single USB-A (J33) is a load switch (U20, active-high enable) gated by
-	 * soc_gpio39/PN.01. Stock DT left that pin a pulled-up input, so the port leaned on the
-	 * board's 100K pull-up (R144) alone and enumerated unreliably — the USBSS0 USB3 drive (and
-	 * its USB2 companion) would intermittently go missing. Model the switch as a regulator so
-	 * the kernel drives the enable high at boot. The other three USB-A ports are powered by the
-	 * onboard USB2 hub (uhubctl), not a SoC GPIO. */
+	 * soc_gpio39/PN.01, which the board also pulls up through R144 (100K to 1V8). Modelling it
+	 * as a regulator gives the kernel the pin; deliberately NOT boot-on, so reg-fixed-voltage
+	 * takes it low at probe and tegra186_utmi_phy_init raises it when xhci brings usb2-2 up.
+	 * VBUS then arrives with the host, as it does on the other three USB-A ports (the onboard
+	 * USB2 hub powers those only once it has enumerated). Asserted any earlier, a SuperSpeed
+	 * device on J33 finishes its Rx.Detect handshake before the host exists and parks: its USB2
+	 * companion still enumerates, the SS link never appears, and nothing short of a VBUS cycle
+	 * recovers it. The MB1 gpio BCT holds the same pin low through the bootloader. */
 	vdd_5v0_usbss0: regulator-usbss0-vbus {
 		compatible = "regulator-fixed";
 		regulator-name = "VDD_5V0_USBSS0";
@@ -26,7 +29,6 @@
 		regulator-max-microvolt = <5000000>;
 		gpio = <&gpio TEGRA234_MAIN_GPIO(N, 1) GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-boot-on;
 		vin-supply = <&vdd_5v0_sys>;
 	};
 };


### PR DESCRIPTION
## Summary

J33's VBUS load switch comes on at the start of MB1 and stays on. A SuperSpeed device plugged into that port therefore powers up tens of seconds before the xHCI exists, and a fair share of them never attach. This hands the pin to the kernel properly: off through the bootloader, raised when xhci brings usb2-2 up.

## Problem

`soc_gpio39/PN.01` gates U20, J33's load switch. MB1 lists it under `gpio-input` with the pinmux pull-up enabled, and R144 (100K to 1V8) backs that up, so VBUS is asserted before any host exists. `regulator-boot-on` then made `reg-fixed-voltage` claim the pin as `GPIOD_OUT_HIGH` at probe, keeping it on. The other three USB-A connectors are powered by the onboard USB2 hub, which only asserts its `PRT_CTL` outputs after it has itself enumerated — i.e. after the host is up.

A SuperSpeed device on J33 runs its Rx.Detect handshake into a dead host and parks. Its USB2 companion still enumerates, because USB2 attach is a static D+ pull-up rather than a handshake, so the connector looks alive while the SS link is simply absent — no `Cannot enable`, no link-training retries, nothing in dmesg at all.

Manufacturing data over 1308 runs:

| connector | SuperSpeed miss rate |
|---|---|
| J33 (top / USBSS0) | **21.8%** |
| J34 middle / USBSS2 | 3.4% |
| J34 bottom / USBSS1 | 3.2% |

150 of the 164 units that ever failed it later passed it untouched, and 130 of 223 retests within 30 minutes on the same fixture passed. It is a boot race, not a defect.

It is also unrecoverable in place: neither a `tegra-xusb` rebind nor a soft reboot drops that rail, so the device is never re-powered. The bench's escalation ladder recovers it on 4 of 289 attempts.

The `regulator-boot-on` model was added to fix the *weak pull-up* — that part worked, and J33's USB2 side is now down to 5.7%. It just kept VBUS early, and it took the pin away from the userspace pulse that used to mask the SuperSpeed half.

## Solution

Drop `regulator-boot-on`, so `reg-fixed-voltage` takes the pin low at probe and `tegra186_utmi_phy_init()` raises it when the xHCI brings up its PHYs. Stock already sets `mode = "host"` on `usb2-2`, which is what that path requires, and the ARK fragment only adds `vbus-supply`. Move the same pin into MB1's `gpio-output-low` so J33 stays dark through the bootloader instead of depending on when the regulator happens to probe.

As a side effect `phy_exit()` now releases the last reference, so a `tegra-xusb` unbind/rebind genuinely power-cycles J33 — the bench gets a working recovery rung, and so does field support.

JAJ and PAB_V3 declare no GPIO-gated VBUS switch and are untouched.

Validated by compiling the p3768 DTB from the staged tree: the regulator carries no `boot-on`, and `usb2-2` still resolves `mode = "host"` with `vbus-supply` pointing at it. On hardware, the thing to watch is that J33's **USB2** stick still enumerates — that proves the regulator does get enabled — before counting SuperSpeed attaches across cold power cycles.