### PR TITLE
fix(flash): wait for the first boot to finish before returning

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ By default `flash.sh` targets NVMe. Other storage layouts:
 ./flash.sh PAB --usb        # USB thumb drive
 ```
 
+Both flashers block until the board has finished its first boot: it generates the SSH host keys then, and cutting power mid-way can leave a unit whose sshd never starts. Leave the USB cable connected. `ARK_FIRST_BOOT_TIMEOUT` overrides the 480 s cap.
+
 When flashing completes, SSH in over Micro USB or WiFi:
 ```
 ssh jetson@jetson.local

--- a/flash.sh
+++ b/flash.sh
@@ -152,6 +152,69 @@ if command -v nmcli > /dev/null 2>&1 && systemctl is-active --quiet NetworkManag
     trap 'sudo rm -f "$NM_FLASH_GUARD"; sudo nmcli general reload' EXIT
 fi
 
+# ── Wait for the flashed image to finish its first boot ─────────────────────
+# The image ships no SSH host keys: /etc/systemd/nvfb.sh generates them on the
+# first boot, and nvfb.service is ordered Before=ssh.service, so an answering
+# port 22 proves the board is past the window where losing power strands it. A
+# key truncated by a power cut is skipped forever afterwards — openssh's
+# create_key() guards on existence, not size — and sshd then never starts.
+# The board serves 192.168.55.1 over the cable it was just flashed on.
+# Keep in sync with the copy in packaging/flash_from_package.sh.
+
+FIRST_BOOT_TIMEOUT="${ARK_FIRST_BOOT_TIMEOUT:-480}"
+JETSON_USB_ADDRESS="192.168.55.1"
+
+jetson_usb_interface() {
+    # Match the device-mode gadget on USB vendor: its interface name and MAC are
+    # per-board, the vendor id is not.
+    local net device
+    for net in /sys/class/net/*; do
+        device="$(readlink -f "$net/device" 2>/dev/null)" || continue
+        if [ "$(cat "$device/../idVendor" 2>/dev/null)" = "0955" ]; then
+            echo "${net##*/}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+wait_for_first_boot() {
+    local start elapsed announced interface addresses
+    start=$(date +%s)
+    announced=0
+    echo ""
+    echo "Waiting for the Jetson to finish its first boot — leave it powered and connected."
+    while :; do
+        elapsed=$(( $(date +%s) - start ))
+        [ "$elapsed" -lt "$FIRST_BOOT_TIMEOUT" ] || break
+        interface="$(jetson_usb_interface || true)"
+        if [ -n "$interface" ]; then
+            # The gadget's DHCP pool is the single address .100; take it directly
+            # rather than depend on a DHCP client running on this host NIC.
+            sudo ip link set "$interface" up 2>/dev/null || true
+            addresses="$(ip -4 -o addr show dev "$interface" 2>/dev/null || true)"
+            case "$addresses" in
+                *"inet 192.168.55."*) ;;
+                *) sudo ip addr add 192.168.55.100/24 dev "$interface" 2>/dev/null || true ;;
+            esac
+            if timeout 2 bash -c "exec 3<>/dev/tcp/$JETSON_USB_ADDRESS/22" 2>/dev/null; then
+                echo "First boot complete after ${elapsed}s — sshd is up on $JETSON_USB_ADDRESS. Safe to power off."
+                return 0
+            fi
+        fi
+        if [ $(( elapsed - announced )) -ge 30 ]; then
+            announced="$elapsed"
+            echo "  still booting (${elapsed}s)"
+        fi
+        sleep 5
+    done
+    echo "" >&2
+    echo "ERROR: no sshd on $JETSON_USB_ADDRESS:22 within ${FIRST_BOOT_TIMEOUT}s — the first boot did not finish." >&2
+    echo "       Keep it powered and cabled; check its console: systemctl status nvfb ssh" >&2
+    echo "       Removing power now can leave a unit whose sshd never starts." >&2
+    return 1
+}
+
 cd "$L4T_DIR"
 
 if [ -n "$ADDITIONAL_DTB_OVERLAY" ]; then
@@ -174,3 +237,11 @@ else
     sudo ${ADDITIONAL_DTB_OVERLAY:+ADDITIONAL_DTB_OVERLAY=$ADDITIONAL_DTB_OVERLAY} \
         ./flash.sh "$FLASH_TARGET" "$STORAGE_DEV"
 fi
+flash_status=$?
+
+if [ "$flash_status" -ne 0 ]; then
+    echo "ERROR: flashing failed (exit $flash_status)." >&2
+    exit "$flash_status"
+fi
+
+wait_for_first_boot || exit 1

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -95,7 +95,7 @@ Or flash the latest release for a product:
 ./flash_from_package.sh pab
 ```
 
-The script downloads the package, extracts it, waits for a Jetson in recovery mode, and flashes. No build tools or kernel source needed — just a Debian/Ubuntu host with USB.
+The script downloads the package, extracts it, waits for a Jetson in recovery mode, flashes, and then waits for the board to finish its first boot (`ARK_FIRST_BOOT_TIMEOUT`, default 480 s). No build tools or kernel source needed — just a Debian/Ubuntu host with USB.
 
 Each version is cached in `~/.ark-jetson-cache/<tag>/` so re-running after a failure or switching between versions doesn't re-download.
 

--- a/packaging/flash_from_package.sh
+++ b/packaging/flash_from_package.sh
@@ -666,13 +666,78 @@ else
     fi
 fi
 
+# ── Wait for the flashed image to finish its first boot ─────────────────────
+# The image ships no SSH host keys: /etc/systemd/nvfb.sh generates them on the
+# first boot, and nvfb.service is ordered Before=ssh.service, so an answering
+# port 22 proves the board is past the window where losing power strands it. A
+# key truncated by a power cut is skipped forever afterwards — openssh's
+# create_key() guards on existence, not size — and sshd then never starts.
+# The board serves 192.168.55.1 over the cable it was just flashed on.
+# Keep in sync with the copy in flash.sh.
+
+FIRST_BOOT_TIMEOUT="${ARK_FIRST_BOOT_TIMEOUT:-480}"
+JETSON_USB_ADDRESS="192.168.55.1"
+
+jetson_usb_interface() {
+    # Match the device-mode gadget on USB vendor: its interface name and MAC are
+    # per-board, the vendor id is not.
+    local net device
+    for net in /sys/class/net/*; do
+        device="$(readlink -f "$net/device" 2>/dev/null)" || continue
+        if [ "$(cat "$device/../idVendor" 2>/dev/null)" = "0955" ]; then
+            echo "${net##*/}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+wait_for_first_boot() {
+    local start elapsed announced interface addresses
+    start=$(date +%s)
+    announced=0
+    echo ""
+    echo "Waiting for the Jetson to finish its first boot — leave it powered and connected."
+    while :; do
+        elapsed=$(( $(date +%s) - start ))
+        [ "$elapsed" -lt "$FIRST_BOOT_TIMEOUT" ] || break
+        interface="$(jetson_usb_interface || true)"
+        if [ -n "$interface" ]; then
+            # The gadget's DHCP pool is the single address .100; take it directly
+            # rather than depend on a DHCP client running on this host NIC.
+            sudo ip link set "$interface" up 2>/dev/null || true
+            addresses="$(ip -4 -o addr show dev "$interface" 2>/dev/null || true)"
+            case "$addresses" in
+                *"inet 192.168.55."*) ;;
+                *) sudo ip addr add 192.168.55.100/24 dev "$interface" 2>/dev/null || true ;;
+            esac
+            if timeout 2 bash -c "exec 3<>/dev/tcp/$JETSON_USB_ADDRESS/22" 2>/dev/null; then
+                echo "First boot complete after ${elapsed}s — sshd is up on $JETSON_USB_ADDRESS. Safe to power off."
+                return 0
+            fi
+        fi
+        if [ $(( elapsed - announced )) -ge 30 ]; then
+            announced="$elapsed"
+            echo "  still booting (${elapsed}s)"
+        fi
+        sleep 5
+    done
+    echo "" >&2
+    echo "ERROR: no sshd on $JETSON_USB_ADDRESS:22 within ${FIRST_BOOT_TIMEOUT}s — the first boot did not finish." >&2
+    echo "       Keep it powered and cabled; check its console: systemctl status nvfb ssh" >&2
+    echo "       Removing power now can leave a unit whose sshd never starts." >&2
+    return 1
+}
+
 echo ""
 echo "========================================="
 echo "  Flash complete!"
 echo "========================================="
+
+wait_for_first_boot
+
 echo ""
-echo "The Jetson will reboot automatically."
-echo "Once booted, connect via: ssh jetson@jetson.local"
+echo "Connect via: ssh jetson@jetson.local"
 echo ""
 echo "Cached data: $CACHE_DIR"
 echo "To free disk space: $0 --clean"


### PR DESCRIPTION
## Summary

`flash.sh` and `packaging/flash_from_package.sh` now block until the flashed board has finished its first boot, and fail loud if it doesn't.

## Problem

The image ships no SSH host keys — `/etc/systemd/nvfb.sh` generates them on the first boot, ordered `Before=ssh.service`. Both flashers returned while that window was still open and told the operator the Jetson would reboot on its own, so cutting power right after a flash was the obvious next move. A key truncated in that window is skipped forever afterwards (openssh's `create_key()` guards on existence, not size) and sshd never starts again: the unit answers ping and refuses port 22 on every later boot. That is what stranded the units flashed onto SSDs and de-powered immediately, and what the bench then reported as a "Jetson dependencies" failure.

## Solution

After a successful flash, poll `192.168.55.1:22` over the same USB cable until sshd answers, up to `ARK_FIRST_BOOT_TIMEOUT` (default 480 s). Port 22 is the gate rather than ping because `nvfb.service` is ordered before `ssh.service`, so a listening sshd proves first boot ran to completion with real host keys.

The gadget NIC is matched on USB vendor `0955` (its name and MAC are per-board) and given `192.168.55.100/24` directly, so the wait doesn't depend on a DHCP client or NetworkManager profile on the flashing host. On timeout the flasher exits non-zero naming the console check; `flash.sh` also now reports a failed flash explicitly instead of exiting silently with the flasher's status.

The wait is duplicated verbatim in both scripts — `flash_from_package.sh` is fetched standalone from `main`, so it can't source anything.

Verified live against a booted Jetson on USB: success and timeout paths both behave, under `set -euo pipefail`.
