### PR TITLE
fix(pab): drive J33's VBUS enable open drain, as the board expects

### DIFF
--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/nv-platform/ark-PAB-overrides.dtsi
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/nv-platform/ark-PAB-overrides.dtsi
@@ -21,13 +21,16 @@
 	 * USB2 hub powers those only once it has enumerated). Asserted any earlier, a SuperSpeed
 	 * device on J33 finishes its Rx.Detect handshake before the host exists and parks: its USB2
 	 * companion still enumerates, the SS link never appears, and nothing short of a VBUS cycle
-	 * recovers it. The MB1 gpio BCT holds the same pin low through the bootloader. */
+	 * recovers it. The MB1 gpio BCT holds the same pin low through the bootloader.
+	 * Open drain: U20's FLG (open-drain fault flag) is wired to the same net so an over-current
+	 * pulls EN low; a push-pull high would fight it. gpio-tegra186 has no native open drain, so
+	 * gpiolib emulates it — "high" is Hi-Z and R144 does the pulling. */
 	vdd_5v0_usbss0: regulator-usbss0-vbus {
 		compatible = "regulator-fixed";
 		regulator-name = "VDD_5V0_USBSS0";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio TEGRA234_MAIN_GPIO(N, 1) GPIO_ACTIVE_HIGH>;
+		gpio = <&gpio TEGRA234_MAIN_GPIO(N, 1) (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		enable-active-high;
 		vin-supply = <&vdd_5v0_sys>;
 	};


### PR DESCRIPTION
## Summary
Declare J33's VBUS-enable GPIO (PN.01) open drain in the PAB device tree so the load switch's own fault flag can still turn the port off.

## Problem
On the carrier, U20's open-drain FLG output is tied to its EN pin, with R144 (100K to 1V8) as the only pull-up; the design intent is that an over-current pulls EN low and the switch shuts itself off. Modelling the pin as a push-pull regulator GPIO (since the boot-on regulator, and unchanged by #121) has the SoC actively driving EN high, so FLG can no longer pull the net down and the pad sources current into FLG for the duration of a fault.

## Solution
Add `GPIO_OPEN_DRAIN` to the regulator's gpio specifier. gpio-tegra186 has no native open-drain support, so gpiolib emulates it: enabled = Hi-Z with R144 pulling up, disabled = driven low. The MB1 output-low hold, the enable at xhci probe and the drop on unbind are unchanged. Compiled the four p3767 SKU DTBs from the staged tree; the node carries gpio flags 0x6.
