### PR TITLE
docs(pab): explain the USB port mapping and the recovery-port detect line

### DIFF
--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/nv-platform/ark-PAB-overrides.dtsi
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/nv-platform/ark-PAB-overrides.dtsi
@@ -85,20 +85,24 @@
 	};
 };
 
-/* Recovery/OTG port carries a micro-USB connector (drop the stock typec link). */
+/* Recovery/OTG port: a mux hands usb2-0 to the FMU's USB, or to the micro-USB when that has VBUS.
+ * No ID pin — the "id" line is inverted VBUS-detect on PZ.01, so active-low reads host idle (FMU)
+ * and device with a recovery cable in. Drop the stock Type-C link. */
 &{/bus@0/padctl@3520000/ports/usb2-0} {
 	/delete-node/ port;
 	connector {
-		compatible = "usb-b-connector", "gpio-usb-b-connector";
+		compatible = "gpio-usb-b-connector", "usb-b-connector";
 		label = "micro-USB";
 		type = "micro";
-		id-gpio = <&gpio TEGRA234_MAIN_GPIO(Z, 1) GPIO_ACTIVE_LOW>;
+		id-gpios = <&gpio TEGRA234_MAIN_GPIO(Z, 1) GPIO_ACTIVE_LOW>;
 	};
 };
 
-/* Carrier USB-A port mapping. */
+/* USB-A mapping: usb2-2 + usb3-0 = J33; usb3-1/usb3-2 = J34 lower/upper, whose USB2 halves are
+ * downstream ports of the USB2 hub on usb2-1 — hence the shared companion (T234 uses it only for
+ * PORT_CAP and the OTG lookup). Leave usb3-3 unused: OTG usb2-0 has no SS companion and the padctl
+ * takes a free usb3 port as its device-mode fake. */
 &{/bus@0/padctl@3520000/ports} {
-	/* usb2-2 + usb3-0 are the single USB-A (J33); point its VBUS at the GPIO-gated switch above. */
 	usb2-2 { vbus-supply = <&vdd_5v0_usbss0>; };
 	usb3-0 { nvidia,usb2-companion = <2>; };
 	usb3-1 { nvidia,usb2-companion = <1>; };


### PR DESCRIPTION
## Summary
Terse comments in `ark-PAB-overrides.dtsi` for the USB port mapping, plus two schema nits on the recovery-port connector node.

## Problem
The fragment named the ports but not the two things the code can't say: usb2-0's `id` line is an inverted VBUS-detect behind a mux (there is no ID pin), and J34's USB2 halves go through the hub, which is why both of its SuperSpeed lanes name usb2-1 as companion. The connector node also had its compatibles in the wrong order and used the singular `id-gpio`, both working only through fallbacks.

## Solution
Say those next to the nodes, and note that usb3-3 has to stay unused because OTG usb2-0 claims it as its device-mode fake port. Reorder the compatible to `"gpio-usb-b-connector", "usb-b-connector"` and rename to `id-gpios`; the driver matches either way and gpiolib resolves both spellings, so no behaviour changes. p3767 SKU DTBs compile from the staged tree.
