### PR TITLE
fix(pab,pab-v3): disable PCIe C7, which neither carrier routes

### DIFF
--- a/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/nv-platform/ark-PAB-overrides.dtsi
+++ b/products/PAB/device_tree/source/hardware/nvidia/t23x/nv-public/nv-platform/ark-PAB-overrides.dtsi
@@ -125,3 +125,10 @@
 	phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-0",
 		    "usb3-1", "usb3-2";
 };
+
+/* PCIe: C1 = M.2 Key E, C4 = M.2 Key M, C8 = the module's own Ethernet controller. C7 (module
+ * PCIE2, x2 on the GBE UPHY) has no pins on this carrier; stock leaves it enabled and it logs
+ * "Phy link never came up" on every boot. */
+&{/bus@0/pcie@141e0000} {
+	status = "disabled";
+};

--- a/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/nv-platform/ark-PAB_V3-overrides.dtsi
+++ b/products/PAB_V3/device_tree/source/hardware/nvidia/t23x/nv-public/nv-platform/ark-PAB_V3-overrides.dtsi
@@ -113,3 +113,10 @@
 	       <&{/bus@0/padctl@3520000/pads/usb3/lanes/usb3-0}>;
 	phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-0";
 };
+
+/* PCIe: C1 = M.2 Key E, C4 = M.2 Key M, C8 = the module's own Ethernet controller. C7 (module
+ * PCIE2, x2 on the GBE UPHY) has no pins on this carrier; stock leaves it enabled and it logs
+ * "Phy link never came up" on every boot. */
+&{/bus@0/pcie@141e0000} {
+	status = "disabled";
+};


### PR DESCRIPTION
## Summary
fixes #122

Disable `pcie@141e0000` (C7) in the PAB and PAB_V3 device trees; it is the one enabled controller with no pins on either carrier.

## Problem
The stock p3768 tree enables C1, C4, C7 and C8. On both carriers the module's PCIE2 pins (C7, x2 on the GBE UPHY, SODIMM pins 40–66) are unconnected, so every boot spends ~2 s in link retries and logs `Phy link never came up` before the driver powers the controller down — noise that a real PCIe fault would hide behind. The controller-to-carrier mapping, from the schematics and a PAB's `lspci`: C1 = M.2 Key E (0001: QCNFA765), C4 = M.2 Key M (0004: NVMe), C8 = the RTL8111 on the module itself (0008), reached through the GBE_MDI pins; the PAB_V3 wires the same three.

## Solution
`status = "disabled"` on C7 in both override files, with the mapping in a comment. Nothing else in the inherited tree needs the same treatment: the C4 endpoint node is disabled by default, the SKU-handling overlay only touches `max-link-speed`/lanes on C7 (no `status`), and the other stock GPIO consumers either sit on balls the module does not expose (`vdd_3v3_pcie` on PAA.05, the EP refclk select on PAA.04) or on pins the carriers wire as the devkit does (PCIe resets, PEX_WAKE, force-recovery, power button). Compiled the p3767-0003 DTB from both staged trees: C7 reads `disabled`, C4 `okay`.
