### PR TITLE
fix(build): derive the toolchain dir from versions.env and check it before staging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -169,9 +169,15 @@ if [ ! -d "$PRODUCT_DIR" ]; then
     exit 1
 fi
 
+# Check the toolchain before staging: a missing one would otherwise surface as a
+# command-not-found from make, after the ~30 min stage + provision.
 THIS_MACHINE="$(uname -m)"
 if [[ "$THIS_MACHINE" != "aarch64" ]]; then
-    export CROSS_COMPILE=$HOME/l4t-gcc/aarch64--glibc--stable-2022.08-1/bin/aarch64-buildroot-linux-gnu-
+    export CROSS_COMPILE="$HOME/l4t-gcc/$TOOLCHAIN_DIRNAME/bin/aarch64-buildroot-linux-gnu-"
+    if [ ! -x "${CROSS_COMPILE}gcc" ]; then
+        echo "ERROR: cross toolchain not found at ${CROSS_COMPILE}gcc — run ./setup.sh" >&2
+        exit 1
+    fi
 fi
 export KERNEL_HEADERS="$SOURCE_DIR/kernel/kernel-jammy-src"
 export INSTALL_MOD_PATH="$L4T_DIR/rootfs/"

--- a/docs/kernel_development.md
+++ b/docs/kernel_development.md
@@ -6,9 +6,10 @@
 
 The steps below build and install the kernel, modules, and DTBs by hand. Adjust the `PAB` path for your target.
 
-Set up the cross-compile environment:
+Set up the cross-compile environment (skip `CROSS_COMPILE` on an aarch64 host):
 ```
-export CROSS_COMPILE=$HOME/l4t-gcc/aarch64--glibc--stable-2022.08-1/bin/aarch64-buildroot-linux-gnu-
+source versions.env
+export CROSS_COMPILE=$HOME/l4t-gcc/$TOOLCHAIN_DIRNAME/bin/aarch64-buildroot-linux-gnu-
 export KERNEL_HEADERS=$PWD/staging/PAB/Linux_for_Tegra/source/kernel/kernel-jammy-src
 export INSTALL_MOD_PATH=$PWD/staging/PAB/Linux_for_Tegra/rootfs/
 cd staging/PAB/Linux_for_Tegra/source

--- a/setup.sh
+++ b/setup.sh
@@ -185,7 +185,6 @@ sudo apt-get install -y -qq make build-essential bc flex bison libssl-dev
 # Toolchain
 mkdir -p "$HOME/l4t-gcc"
 TOOLCHAIN_FILENAME=$(basename "$TOOLCHAIN_URL")
-TOOLCHAIN_DIRNAME=${TOOLCHAIN_FILENAME%.tar.bz2}
 
 if [ ! -d "$HOME/l4t-gcc/$TOOLCHAIN_DIRNAME" ]; then
     download_with_retry "$TOOLCHAIN_URL" "$HOME/l4t-gcc"

--- a/versions.env
+++ b/versions.env
@@ -26,6 +26,7 @@ PUBLIC_SOURCES_FILE="public_sources_${_release_tag}.tbz2"
 
 # Bootlin gcc cross-toolchain — pinned to its own r36 release, independent of the L4T patch revision.
 TOOLCHAIN_URL="https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v3.0/toolchain/aarch64--glibc--stable-2022.08-1.tar.bz2"
+TOOLCHAIN_DIRNAME="$(basename "$TOOLCHAIN_URL" .tar.bz2)"
 
 unset _release_lc _release_path _release_tag
 


### PR DESCRIPTION
## Summary
Follow-up to #128 (branched from its head, so the diff collapses to the last commit once that merges).

## Problem
`build.sh` and `docs/kernel_development.md` hardcoded the bootlin toolchain dirname that `versions.env` already pins via `TOOLCHAIN_URL`, so bumping the toolchain there would leave the build silently pointing at the old directory. A missing toolchain only surfaced as a `command not found` from make, after the ~30 min stage + provision.

## Solution
`versions.env` derives `TOOLCHAIN_DIRNAME` once; `setup.sh`, `build.sh`, and the docs use it. `build.sh` checks `${CROSS_COMPILE}gcc` is executable before staging and points at `setup.sh` if not (skipped on aarch64 hosts, where #128 builds natively).